### PR TITLE
[BE] 호스트 공간 정보 삭제 기능을 구현한다.

### DIFF
--- a/src/main/java/com/beour/space/host/controller/SpaceController.java
+++ b/src/main/java/com/beour/space/host/controller/SpaceController.java
@@ -4,10 +4,7 @@ import com.beour.space.host.dto.SpaceRegisterRequestDto;
 import com.beour.space.host.service.SpaceService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -20,5 +17,11 @@ public class SpaceController {
     public ResponseEntity<?> registerSpace(@RequestBody SpaceRegisterRequestDto dto) {
         Long id = spaceService.registerSpace(dto);
         return ResponseEntity.ok("공간이 등록되었습니다. ID: " + id);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteSpace(@PathVariable Long id) {
+        spaceService.deleteSpace(id);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/beour/space/host/entity/Space.java
+++ b/src/main/java/com/beour/space/host/entity/Space.java
@@ -65,4 +65,8 @@ public class Space {
 
     @OneToMany(mappedBy = "space", cascade = CascadeType.ALL)
     private List<SpaceImage> spaceImages = new ArrayList<>();
+
+    public void delete() {
+        this.deletedAt = LocalDateTime.now();
+    }
 }

--- a/src/main/java/com/beour/space/host/service/SpaceService.java
+++ b/src/main/java/com/beour/space/host/service/SpaceService.java
@@ -85,4 +85,12 @@ public class SpaceService {
 
         return space.getId();
     }
+
+    @Transactional
+    public void deleteSpace(Long spaceId) {
+        Space space = spaceRepository.findById(spaceId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 공간입니다."));
+        space.delete();
+    }
+
 }


### PR DESCRIPTION
## **❗ Issue**

- [#5] **호스트 공간 정보 ‘삭제’ 기능 구현**

## **✨ 구현한 기능**

- 공간 정보 삭제(소프트 삭제)

## **📢 논의하고 싶은 내용**

- 노션에 정리된 채점표에서 재사용성과 안정성에 관련 문항에 대해 피드백 부탁드립니다.
- 브랜치를 분리가 미숙한 것 같은데, 커밋별로 브랜치를 어떻게 나눴으면 좋았을 지 아직도 확실히 모르겠습니다!.. 
![image](https://github.com/user-attachments/assets/219e7041-c392-4dd2-8803-2fc894cbb1d3)
요렇게 나눴어야 할까요?

## **🎸 기타(호스트 공간 정보 등록과 동일)**

- 나중에 SpaceService가 너무 커지면 리팩토링 시 SpaceReadService, SpaceCommandService 등으로 분리 고려해야 함
- 브랜치는 feat/space-read, feat/space-update, feat/space-delete로 나눔 -> SpaceService 병합 충돌할 때 각 코드를 복붙하면 됨