### PR TITLE
[BE] 새로 등록된 공간 조회시 responseBody 리팩터링

### DIFF
--- a/src/main/java/com/beour/space/guest/dto/RecentCreatedSpcaceListResponseDto.java
+++ b/src/main/java/com/beour/space/guest/dto/RecentCreatedSpcaceListResponseDto.java
@@ -7,24 +7,29 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+//todo : 수정사항 더 없으면 주석 제거하기
 @Getter
 @Builder
 @RequiredArgsConstructor
 @AllArgsConstructor
 public class RecentCreatedSpcaceListResponseDto {
 
-    private String address;
-    private String name;
-    private int pricePerHour;
-    private boolean like;
+    private String addressAndName;
+//    private String name;
+//    private int pricePerHour;
+//    private boolean like;
+    private String thumbnailUrl;
+    private String description;
     private LocalDateTime createdAt;
 
-    public RecentCreatedSpcaceListResponseDto dtoFrom(Space space, boolean like){
+    public RecentCreatedSpcaceListResponseDto dtoFrom(Space space){
         return RecentCreatedSpcaceListResponseDto.builder()
-            .address(space.getAddress())
-            .name(space.getName())
-            .pricePerHour(space.getPricePerHour())
-            .like(like)
+            .addressAndName(space.getAddress().split(" ")[1] + " / " + space.getName())
+//            .name(space.getName())
+//            .pricePerHour(space.getPricePerHour())
+//            .like(like)
+            .thumbnailUrl(space.getThumbnailUrl())
+            .description(space.getDescription().getDescription())
             .createdAt(space.getCreatedAt())
             .build();
     }

--- a/src/main/java/com/beour/space/guest/service/GuestSpaceService.java
+++ b/src/main/java/com/beour/space/guest/service/GuestSpaceService.java
@@ -67,8 +67,8 @@ public class GuestSpaceService {
 
         return spaces.stream()
             .map(space -> {
-                boolean isLiked = likeRepository.existsByUserIdAndSpaceIdAndDeletedAtIsNull(user.getId(), space.getId());
-                return new RecentCreatedSpcaceListResponseDto().dtoFrom(space, isLiked);
+//                boolean isLiked = likeRepository.existsByUserIdAndSpaceIdAndDeletedAtIsNull(user.getId(), space.getId());
+                return new RecentCreatedSpcaceListResponseDto().dtoFrom(space);
             })
             .collect(Collectors.toList());
     }


### PR DESCRIPTION
## ❗ Issue
[#40] 새로 등록된 공간 조회

## ✨ 구현한 기능
- 최근 등록된 공간 조회의 responsebody에 담을 data를 수정
   -  공간 주소와 이름을 합쳐서 보내도록 수정
   - 시간당 가격 삭제
   - 찜 유무 삭제


## 🎸 기타
디자인 변경으로 responsebody 수정!!




