### PR TITLE
[BE] reservation entity 컬럼 추가 및 관련된 게스트 예약 기능 코드 수정

### DIFF
--- a/src/main/java/com/beour/reservation/commons/entity/Reservation.java
+++ b/src/main/java/com/beour/reservation/commons/entity/Reservation.java
@@ -2,8 +2,10 @@ package com.beour.reservation.commons.entity;
 
 import com.beour.global.entity.BaseTimeEntity;
 import com.beour.reservation.commons.enums.ReservationStatus;
+import com.beour.reservation.commons.enums.UsagePurpose;
 import com.beour.space.domain.entity.Space;
 import com.beour.user.entity.User;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -43,6 +45,13 @@ public class Reservation extends BaseTimeEntity {
 
     @Enumerated(EnumType.STRING)
     private ReservationStatus status;
+
+    @Enumerated(EnumType.STRING)
+    private UsagePurpose usagePurpose;
+
+    @Column(length = 200)
+    private String requestMessage;
+
     private LocalDate date;
     private LocalTime startTime;
     private LocalTime endTime;
@@ -59,11 +68,15 @@ public class Reservation extends BaseTimeEntity {
     }
 
     @Builder
-    private Reservation(User guest, User host, Space space, ReservationStatus status, LocalDate date, LocalTime startTime, LocalTime endTime, int price, int guestCount){
+    private Reservation(User guest, User host, Space space, ReservationStatus status,
+                        UsagePurpose usagePurpose, String requestMessage, LocalDate date,
+                        LocalTime startTime, LocalTime endTime, int price, int guestCount){
         this.guest = guest;
         this.host = host;
         this.space = space;
         this.status = status;
+        this.usagePurpose = usagePurpose;
+        this.requestMessage = requestMessage;
         this.date = date;
         this.startTime = startTime;
         this.endTime = endTime;

--- a/src/main/java/com/beour/reservation/commons/enums/UsagePurpose.java
+++ b/src/main/java/com/beour/reservation/commons/enums/UsagePurpose.java
@@ -1,0 +1,19 @@
+package com.beour.reservation.commons.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum UsagePurpose {
+
+    GROUP_MEETING("단체 모임"),
+    COOKING_PRACTICE("요리 연습"),
+    BARISTA_TRAINING("바리스타 실습"),
+    FLEA_MARKET("플리마켓"),
+    FILMING("촬영"),
+    OTHER("기타");
+
+    private final String text;
+    public static final UsagePurpose DEFAULT = OTHER;
+}

--- a/src/main/java/com/beour/reservation/guest/dto/ReservationCreateRequest.java
+++ b/src/main/java/com/beour/reservation/guest/dto/ReservationCreateRequest.java
@@ -1,7 +1,9 @@
 package com.beour.reservation.guest.dto;
 
+import com.beour.reservation.commons.enums.UsagePurpose;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import lombok.AllArgsConstructor;
@@ -34,4 +36,9 @@ public class ReservationCreateRequest {
     @Min(1)
     private int guestCount;
 
+    @NotNull(message = "이용 목적 필수")
+    private UsagePurpose usagePurpose;
+
+    @Size(max = 200, message = "요청 사항은 200자 이내로 입력해주세요.")
+    private String requestMessage;
 }

--- a/src/main/java/com/beour/reservation/guest/dto/ReservationListResponseDto.java
+++ b/src/main/java/com/beour/reservation/guest/dto/ReservationListResponseDto.java
@@ -2,6 +2,7 @@ package com.beour.reservation.guest.dto;
 
 import com.beour.reservation.commons.entity.Reservation;
 import com.beour.reservation.commons.enums.ReservationStatus;
+import com.beour.reservation.commons.enums.UsagePurpose;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import lombok.Builder;
@@ -21,11 +22,15 @@ public class ReservationListResponseDto {
     private int price;
     private int guestCount;
     private ReservationStatus status;
+    private UsagePurpose usagePurpose;
+    private String requestMessage;
     private Long reviewId;
 
     @Builder
-    private ReservationListResponseDto(Long reservationId, String spaceName, String spaceThumbImageUrl, LocalDate date, LocalTime startTime, LocalTime endTime,
-        int price, int guestCount, ReservationStatus status, Long reviewId){
+    private ReservationListResponseDto(Long reservationId, String spaceName, String spaceThumbImageUrl,
+                                       LocalDate date, LocalTime startTime, LocalTime endTime,
+                                       int price, int guestCount, ReservationStatus status,
+                                       UsagePurpose usagePurpose, String requestMessage, Long reviewId){
         this.reservationId = reservationId;
         this.spaceName = spaceName;
         this.spaceThumbImageUrl = spaceThumbImageUrl;
@@ -35,36 +40,41 @@ public class ReservationListResponseDto {
         this.price = price;
         this.guestCount = guestCount;
         this.status = status;
+        this.usagePurpose = usagePurpose;
+        this.requestMessage = requestMessage;
         this.reviewId = reviewId;
     }
 
     public static ReservationListResponseDto of(Reservation reservation){
         return ReservationListResponseDto.builder()
-            .reservationId(reservation.getId())
-            .spaceName(reservation.getSpace().getName())
-            .spaceThumbImageUrl(reservation.getSpace().getThumbnailUrl())
-            .date(reservation.getDate())
-            .startTime(reservation.getStartTime())
-            .endTime(reservation.getEndTime())
-            .price(reservation.getPrice())
-            .guestCount(reservation.getGuestCount())
-            .status(reservation.getStatus())
-            .build();
+                .reservationId(reservation.getId())
+                .spaceName(reservation.getSpace().getName())
+                .spaceThumbImageUrl(reservation.getSpace().getThumbnailUrl())
+                .date(reservation.getDate())
+                .startTime(reservation.getStartTime())
+                .endTime(reservation.getEndTime())
+                .price(reservation.getPrice())
+                .guestCount(reservation.getGuestCount())
+                .status(reservation.getStatus())
+                .usagePurpose(reservation.getUsagePurpose())
+                .requestMessage(reservation.getRequestMessage())
+                .build();
     }
 
     public static ReservationListResponseDto of(Reservation reservation, Long reviewId){
         return ReservationListResponseDto.builder()
-            .reservationId(reservation.getId())
-            .spaceName(reservation.getSpace().getName())
-            .spaceThumbImageUrl(reservation.getSpace().getThumbnailUrl())
-            .date(reservation.getDate())
-            .startTime(reservation.getStartTime())
-            .endTime(reservation.getEndTime())
-            .price(reservation.getPrice())
-            .guestCount(reservation.getGuestCount())
-            .status(reservation.getStatus())
-            .reviewId(reviewId)
-            .build();
+                .reservationId(reservation.getId())
+                .spaceName(reservation.getSpace().getName())
+                .spaceThumbImageUrl(reservation.getSpace().getThumbnailUrl())
+                .date(reservation.getDate())
+                .startTime(reservation.getStartTime())
+                .endTime(reservation.getEndTime())
+                .price(reservation.getPrice())
+                .guestCount(reservation.getGuestCount())
+                .status(reservation.getStatus())
+                .usagePurpose(reservation.getUsagePurpose())
+                .requestMessage(reservation.getRequestMessage())
+                .reviewId(reviewId)
+                .build();
     }
-
 }

--- a/src/main/java/com/beour/user/dto/ChangePasswordRequestDto.java
+++ b/src/main/java/com/beour/user/dto/ChangePasswordRequestDto.java
@@ -8,11 +8,8 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-<<<<<<< test/MyInformationService
 @AllArgsConstructor
 @Builder
-=======
->>>>>>> develop
 public class ChangePasswordRequestDto {
 
     @ValidPassword


### PR DESCRIPTION
## ❗ Issue
[#63] reservation entity 컬럼 추가 및 관련된 게스트 예약 기능 코드 수정

## ✨ 추가 기능
[64e2b45ba0e7b08c2dce7a60782665cd72059236] 주요 변경사항:

![image](https://github.com/user-attachments/assets/cd6789e6-706d-4cab-b9d5-c46aa0874a0d)

1. 새로운 UsagePurpose Enum 추가
단체 모임, 요리 연습, 바리스타 실습, 플리마켓, 촬영, 기타 총 6개 카테고리
기본값은 '기타'로 설정

2. Reservation Entity 수정
UsagePurpose usagePurpose 필드 추가 (Enum 타입)
String requestMessage 필드 추가 (200자 제한)
Builder 패턴 생성자에 새 필드들 추가

3. ReservationCreateRequest DTO 수정
UsagePurpose usagePurpose 필드 추가 (https://github.com/NotNull 검증)
String requestMessage 필드 추가 (@SiZe(max = 200) 검증)

4. ReservationListResponseDto 수정
새로운 필드들을 응답에 포함
of() 메서드들 수정하여 새 필드들 매핑

6. ReservationGuestService 수정
createReservation() 메서드의 Reservation 빌더에 새 필드들 추가