### PR TITLE
[BE] 호스트 메인화면 - 예약 정보 DTO 수정, 예약 상태 필터링 기능을 추가한다.

### DIFF
--- a/src/main/java/com/beour/reservation/host/dto/HostReservationListResponseDto.java
+++ b/src/main/java/com/beour/reservation/host/dto/HostReservationListResponseDto.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
 import java.time.LocalTime;
 
 @Getter
@@ -19,10 +20,12 @@ public class HostReservationListResponseDto {
     private LocalTime startTime;
     private LocalTime endTime;
     private int guestCount;
+    private boolean isCurrentlyInUse;
 
     @Builder
     private HostReservationListResponseDto(Long reservationId, String guestName, ReservationStatus status,
-                                           String spaceName, LocalTime startTime, LocalTime endTime, int guestCount) {
+                                           String spaceName, LocalTime startTime, LocalTime endTime,
+                                           int guestCount, boolean isCurrentlyInUse) {
         this.reservationId = reservationId;
         this.guestName = guestName;
         this.status = status;
@@ -30,6 +33,7 @@ public class HostReservationListResponseDto {
         this.startTime = startTime;
         this.endTime = endTime;
         this.guestCount = guestCount;
+        this.isCurrentlyInUse = isCurrentlyInUse;
     }
 
     public static HostReservationListResponseDto of(Reservation reservation) {
@@ -41,6 +45,18 @@ public class HostReservationListResponseDto {
                 .startTime(reservation.getStartTime())
                 .endTime(reservation.getEndTime())
                 .guestCount(reservation.getGuestCount())
+                .isCurrentlyInUse(calculateCurrentlyInUse(reservation))
                 .build();
+    }
+
+    private static boolean calculateCurrentlyInUse(Reservation reservation) {
+        LocalDate today = LocalDate.now();
+        LocalTime now = LocalTime.now();
+
+        // 서비스에서 이미 ACCEPTED 상태만 필터링되어 전달되므로,
+        // 예약 날짜가 오늘이며, 현재 시간이 시작시간과 종료시간 사이에 있는 경우만 확인
+        return reservation.getDate().equals(today) &&
+                !now.isBefore(reservation.getStartTime()) &&
+                now.isBefore(reservation.getEndTime());
     }
 }

--- a/src/main/java/com/beour/reservation/host/service/ReservationHostService.java
+++ b/src/main/java/com/beour/reservation/host/service/ReservationHostService.java
@@ -3,6 +3,7 @@ package com.beour.reservation.host.service;
 import com.beour.global.exception.exceptionType.SpaceNotFoundException;
 import com.beour.global.exception.exceptionType.UserNotFoundException;
 import com.beour.reservation.commons.entity.Reservation;
+import com.beour.reservation.commons.enums.ReservationStatus;
 import com.beour.reservation.commons.exceptionType.ReservationNotFound;
 import com.beour.reservation.commons.repository.ReservationRepository;
 import com.beour.reservation.host.dto.HostReservationListResponseDto;
@@ -18,6 +19,7 @@ import org.springframework.stereotype.Service;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Service
@@ -50,12 +52,17 @@ public class ReservationHostService {
         List<Reservation> reservationList = reservationRepository.findByHostIdAndDateAndDeletedAtIsNull(
                 host.getId(), date);
 
-        if (reservationList.isEmpty()) {
-            throw new ReservationNotFound("해당 날짜에 예약이 없습니다.");
+        // 예약 상태가 ACCEPTED인 것만 필터링
+        List<Reservation> acceptedReservations = reservationList.stream()
+                .filter(reservation -> reservation.getStatus() == ReservationStatus.ACCEPTED)
+                .collect(Collectors.toList());
+
+        if (acceptedReservations.isEmpty()) {
+            throw new ReservationNotFound("해당 날짜에 확정된 예약이 없습니다.");
         }
 
         List<HostReservationListResponseDto> responseDtoList = new ArrayList<>();
-        for (Reservation reservation : reservationList) {
+        for (Reservation reservation : acceptedReservations) {
             responseDtoList.add(HostReservationListResponseDto.of(reservation));
         }
 
@@ -77,12 +84,17 @@ public class ReservationHostService {
         List<Reservation> reservationList = reservationRepository.findByHostIdAndDateAndSpaceIdAndDeletedAtIsNull(
                 host.getId(), date, spaceId);
 
-        if (reservationList.isEmpty()) {
-            throw new ReservationNotFound("해당 날짜와 공간에 예약이 없습니다.");
+        // 예약 상태가 ACCEPTED인 것만 필터링
+        List<Reservation> acceptedReservations = reservationList.stream()
+                .filter(reservation -> reservation.getStatus() == ReservationStatus.ACCEPTED)
+                .collect(Collectors.toList());
+
+        if (acceptedReservations.isEmpty()) {
+            throw new ReservationNotFound("해당 날짜와 공간에 확정된 예약이 없습니다.");
         }
 
         List<HostReservationListResponseDto> responseDtoList = new ArrayList<>();
-        for (Reservation reservation : reservationList) {
+        for (Reservation reservation : acceptedReservations) {
             responseDtoList.add(HostReservationListResponseDto.of(reservation));
         }
 


### PR DESCRIPTION
## ❗ Issue
[#66] 호스트 메인화면 - 예약 정보 확인하기

## ✨ 구현한 기능
![image](https://github.com/user-attachments/assets/ea5a0999-c47e-4a42-8b79-473473efd9eb)

[메인화면-오늘의 예약 전체 보기], [메인화면-해당 공간의 오늘의 예약 보기] 
+예약 데이터에 '지금 사용중 여부' 데이터도 추가하기
+예약 상태가 ACCEPTED인 것만 필터링