### PR TITLE
[BE] 호스트 예약캘린더 - 날짜별 예약 확인 및 필터링 기능을 구현한다.

### DIFF
--- a/src/main/java/com/beour/reservation/commons/repository/ReservationRepository.java
+++ b/src/main/java/com/beour/reservation/commons/repository/ReservationRepository.java
@@ -35,4 +35,5 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
     List<Reservation> findByHostIdAndDateAndDeletedAtIsNull(Long hostId, LocalDate date);
     List<Reservation> findByHostIdAndDateAndSpaceIdAndDeletedAtIsNull(Long hostId, LocalDate date, Long spaceId);
     List<Reservation> findByHostIdAndDateAndStatusAndDeletedAtIsNull(Long hostId, LocalDate date, ReservationStatus status);
+    List<Reservation> findByHostIdAndDateAndSpaceIdAndStatusAndDeletedAtIsNull(Long hostId, LocalDate date, Long spaceId, ReservationStatus status);
 }

--- a/src/main/java/com/beour/reservation/commons/repository/ReservationRepository.java
+++ b/src/main/java/com/beour/reservation/commons/repository/ReservationRepository.java
@@ -15,23 +15,24 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
     List<Reservation> findBySpaceIdAndDateAndStatusNot(Long spaceId, LocalDate date, ReservationStatus status);
 
     @Query("SELECT r FROM Reservation r " +
-        "WHERE r.guest.id = :guestId AND " +
-        "(r.date > :today OR (r.date = :today AND r.startTime > :now))")
+            "WHERE r.guest.id = :guestId AND " +
+            "(r.date > :today OR (r.date = :today AND r.startTime > :now))")
     List<Reservation> findUpcomingReservationsByGuest(
-        @Param("guestId") Long guestId,
-        @Param("today") LocalDate today,
-        @Param("now") LocalTime now
+            @Param("guestId") Long guestId,
+            @Param("today") LocalDate today,
+            @Param("now") LocalTime now
     );
 
     @Query("SELECT r FROM Reservation r " +
-        "WHERE r.guest.id = :guestId AND " +
-        "(r.date < :today OR (r.date = :today AND r.endTime <= :now))")
+            "WHERE r.guest.id = :guestId AND " +
+            "(r.date < :today OR (r.date = :today AND r.endTime <= :now))")
     List<Reservation> findPastReservationsByGuest(
-        @Param("guestId") Long guestId,
-        @Param("today") LocalDate today,
-        @Param("now") LocalTime now
+            @Param("guestId") Long guestId,
+            @Param("today") LocalDate today,
+            @Param("now") LocalTime now
     );
 
     List<Reservation> findByHostIdAndDateAndDeletedAtIsNull(Long hostId, LocalDate date);
     List<Reservation> findByHostIdAndDateAndSpaceIdAndDeletedAtIsNull(Long hostId, LocalDate date, Long spaceId);
+    List<Reservation> findByHostIdAndDateAndStatusAndDeletedAtIsNull(Long hostId, LocalDate date, ReservationStatus status);
 }

--- a/src/main/java/com/beour/reservation/host/controller/ReservationCalendarController.java
+++ b/src/main/java/com/beour/reservation/host/controller/ReservationCalendarController.java
@@ -1,0 +1,38 @@
+package com.beour.reservation.host.controller;
+
+import com.beour.global.response.ApiResponse;
+import com.beour.reservation.host.dto.CalendarReservationResponseDto;
+import com.beour.reservation.host.service.ReservationCalendarService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+public class ReservationCalendarController {
+
+    private final ReservationCalendarService reservationCalendarService;
+
+    @GetMapping("/api/host/calendar/reservations")
+    public ApiResponse<List<CalendarReservationResponseDto>> getHostCalendarReservations(
+            @RequestParam(value = "date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
+        return ApiResponse.ok(reservationCalendarService.getHostCalendarReservations(date));
+    }
+
+    @GetMapping("/api/host/calendar/reservations/pending")
+    public ApiResponse<List<CalendarReservationResponseDto>> getHostPendingReservations(
+            @RequestParam(value = "date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
+        return ApiResponse.ok(reservationCalendarService.getHostPendingReservations(date));
+    }
+
+    @GetMapping("/api/host/calendar/reservations/accepted")
+    public ApiResponse<List<CalendarReservationResponseDto>> getHostAcceptedReservations(
+            @RequestParam(value = "date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
+        return ApiResponse.ok(reservationCalendarService.getHostAcceptedReservations(date));
+    }
+}

--- a/src/main/java/com/beour/reservation/host/controller/ReservationCalendarController.java
+++ b/src/main/java/com/beour/reservation/host/controller/ReservationCalendarController.java
@@ -20,19 +20,22 @@ public class ReservationCalendarController {
 
     @GetMapping("/api/host/calendar/reservations")
     public ApiResponse<List<CalendarReservationResponseDto>> getHostCalendarReservations(
-            @RequestParam(value = "date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
-        return ApiResponse.ok(reservationCalendarService.getHostCalendarReservations(date));
+            @RequestParam(value = "date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
+            @RequestParam(value = "spaceId", required = false) Long spaceId) {
+        return ApiResponse.ok(reservationCalendarService.getHostCalendarReservations(date, spaceId));
     }
 
     @GetMapping("/api/host/calendar/reservations/pending")
     public ApiResponse<List<CalendarReservationResponseDto>> getHostPendingReservations(
-            @RequestParam(value = "date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
-        return ApiResponse.ok(reservationCalendarService.getHostPendingReservations(date));
+            @RequestParam(value = "date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
+            @RequestParam(value = "spaceId", required = false) Long spaceId) {
+        return ApiResponse.ok(reservationCalendarService.getHostPendingReservations(date, spaceId));
     }
 
     @GetMapping("/api/host/calendar/reservations/accepted")
     public ApiResponse<List<CalendarReservationResponseDto>> getHostAcceptedReservations(
-            @RequestParam(value = "date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date) {
-        return ApiResponse.ok(reservationCalendarService.getHostAcceptedReservations(date));
+            @RequestParam(value = "date") @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
+            @RequestParam(value = "spaceId", required = false) Long spaceId) {
+        return ApiResponse.ok(reservationCalendarService.getHostAcceptedReservations(date, spaceId));
     }
 }

--- a/src/main/java/com/beour/reservation/host/dto/CalendarReservationResponseDto.java
+++ b/src/main/java/com/beour/reservation/host/dto/CalendarReservationResponseDto.java
@@ -1,0 +1,46 @@
+package com.beour.reservation.host.dto;
+
+import com.beour.reservation.commons.entity.Reservation;
+import com.beour.reservation.commons.enums.ReservationStatus;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalTime;
+
+@Getter
+@NoArgsConstructor
+public class CalendarReservationResponseDto {
+
+    private Long reservationId;
+    private String guestName;
+    private ReservationStatus status;
+    private String spaceName;
+    private LocalTime startTime;
+    private LocalTime endTime;
+    private int guestCount;
+
+    @Builder
+    private CalendarReservationResponseDto(Long reservationId, String guestName, ReservationStatus status,
+                                           String spaceName, LocalTime startTime, LocalTime endTime, int guestCount) {
+        this.reservationId = reservationId;
+        this.guestName = guestName;
+        this.status = status;
+        this.spaceName = spaceName;
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.guestCount = guestCount;
+    }
+
+    public static CalendarReservationResponseDto of(Reservation reservation) {
+        return CalendarReservationResponseDto.builder()
+                .reservationId(reservation.getId())
+                .guestName(reservation.getGuest().getName())
+                .status(reservation.getStatus())
+                .spaceName(reservation.getSpace().getName())
+                .startTime(reservation.getStartTime())
+                .endTime(reservation.getEndTime())
+                .guestCount(reservation.getGuestCount())
+                .build();
+    }
+}

--- a/src/main/java/com/beour/reservation/host/service/ReservationCalendarService.java
+++ b/src/main/java/com/beour/reservation/host/service/ReservationCalendarService.java
@@ -1,0 +1,67 @@
+package com.beour.reservation.host.service;
+
+import com.beour.global.exception.exceptionType.UserNotFoundException;
+import com.beour.reservation.host.dto.CalendarReservationResponseDto;
+import com.beour.reservation.commons.entity.Reservation;
+import com.beour.reservation.commons.enums.ReservationStatus;
+import com.beour.reservation.commons.repository.ReservationRepository;
+import com.beour.user.entity.User;
+import com.beour.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+public class ReservationCalendarService {
+
+    private final ReservationRepository reservationRepository;
+    private final UserRepository userRepository;
+
+    public List<CalendarReservationResponseDto> getHostCalendarReservations(LocalDate date) {
+        User host = findUserFromToken();
+
+        List<Reservation> reservationList = reservationRepository.findByHostIdAndDateAndDeletedAtIsNull(
+                host.getId(), date);
+
+        return convertToCalendarResponseDto(reservationList);
+    }
+
+    public List<CalendarReservationResponseDto> getHostPendingReservations(LocalDate date) {
+        User host = findUserFromToken();
+
+        List<Reservation> reservationList = reservationRepository.findByHostIdAndDateAndStatusAndDeletedAtIsNull(
+                host.getId(), date, ReservationStatus.PENDING);
+
+        return convertToCalendarResponseDto(reservationList);
+    }
+
+    public List<CalendarReservationResponseDto> getHostAcceptedReservations(LocalDate date) {
+        User host = findUserFromToken();
+
+        List<Reservation> reservationList = reservationRepository.findByHostIdAndDateAndStatusAndDeletedAtIsNull(
+                host.getId(), date, ReservationStatus.ACCEPTED);
+
+        return convertToCalendarResponseDto(reservationList);
+    }
+
+    private List<CalendarReservationResponseDto> convertToCalendarResponseDto(List<Reservation> reservationList) {
+        List<CalendarReservationResponseDto> responseDtoList = new ArrayList<>();
+        for (Reservation reservation : reservationList) {
+            responseDtoList.add(CalendarReservationResponseDto.of(reservation));
+        }
+        return responseDtoList;
+    }
+
+    private User findUserFromToken() {
+        String loginId = SecurityContextHolder.getContext().getAuthentication().getName();
+
+        return userRepository.findByLoginIdAndDeletedAtIsNull(loginId).orElseThrow(
+                () -> new UserNotFoundException("해당 유저를 찾을 수 없습니다.")
+        );
+    }
+}

--- a/src/main/java/com/beour/reservation/host/service/ReservationCalendarService.java
+++ b/src/main/java/com/beour/reservation/host/service/ReservationCalendarService.java
@@ -28,53 +28,45 @@ public class ReservationCalendarService {
 
     public List<CalendarReservationResponseDto> getHostCalendarReservations(LocalDate date, Long spaceId) {
         User host = findUserFromToken();
-
-        List<Reservation> reservationList;
-
-        if (spaceId != null) {
-            validateSpaceOwnership(host, spaceId);
-            reservationList = reservationRepository.findByHostIdAndDateAndSpaceIdAndDeletedAtIsNull(
-                    host.getId(), date, spaceId);
-        } else {
-            reservationList = reservationRepository.findByHostIdAndDateAndDeletedAtIsNull(
-                    host.getId(), date);
-        }
-
+        List<Reservation> reservationList = getReservationListDependingOnSpaceId(host, date, spaceId, null);
         return convertToCalendarResponseDto(reservationList);
     }
 
     public List<CalendarReservationResponseDto> getHostPendingReservations(LocalDate date, Long spaceId) {
         User host = findUserFromToken();
-
-        List<Reservation> reservationList;
-
-        if (spaceId != null) {
-            validateSpaceOwnership(host, spaceId);
-            reservationList = reservationRepository.findByHostIdAndDateAndSpaceIdAndStatusAndDeletedAtIsNull(
-                    host.getId(), date, spaceId, ReservationStatus.PENDING);
-        } else {
-            reservationList = reservationRepository.findByHostIdAndDateAndStatusAndDeletedAtIsNull(
-                    host.getId(), date, ReservationStatus.PENDING);
-        }
-
+        List<Reservation> reservationList = getReservationListDependingOnSpaceId(host, date, spaceId, ReservationStatus.PENDING);
         return convertToCalendarResponseDto(reservationList);
     }
 
     public List<CalendarReservationResponseDto> getHostAcceptedReservations(LocalDate date, Long spaceId) {
         User host = findUserFromToken();
+        List<Reservation> reservationList = getReservationListDependingOnSpaceId(host, date, spaceId, ReservationStatus.ACCEPTED);
+        return convertToCalendarResponseDto(reservationList);
+    }
 
-        List<Reservation> reservationList;
-
+    private List<Reservation> getReservationListDependingOnSpaceId(User host, LocalDate date, Long spaceId, ReservationStatus status) {
         if (spaceId != null) {
             validateSpaceOwnership(host, spaceId);
-            reservationList = reservationRepository.findByHostIdAndDateAndSpaceIdAndStatusAndDeletedAtIsNull(
-                    host.getId(), date, spaceId, ReservationStatus.ACCEPTED);
+            if (status != null) {
+                return reservationRepository.findByHostIdAndDateAndSpaceIdAndStatusAndDeletedAtIsNull(
+                        host.getId(), date, spaceId, status
+                );
+            } else {
+                return reservationRepository.findByHostIdAndDateAndSpaceIdAndDeletedAtIsNull(
+                        host.getId(), date, spaceId
+                );
+            }
         } else {
-            reservationList = reservationRepository.findByHostIdAndDateAndStatusAndDeletedAtIsNull(
-                    host.getId(), date, ReservationStatus.ACCEPTED);
+            if (status != null) {
+                return reservationRepository.findByHostIdAndDateAndStatusAndDeletedAtIsNull(
+                        host.getId(), date, status
+                );
+            } else {
+                return reservationRepository.findByHostIdAndDateAndDeletedAtIsNull(
+                        host.getId(), date
+                );
+            }
         }
-
-        return convertToCalendarResponseDto(reservationList);
     }
 
     private void validateSpaceOwnership(User host, Long spaceId) {

--- a/src/main/java/com/beour/reservation/host/service/ReservationCalendarService.java
+++ b/src/main/java/com/beour/reservation/host/service/ReservationCalendarService.java
@@ -1,10 +1,13 @@
 package com.beour.reservation.host.service;
 
+import com.beour.global.exception.exceptionType.SpaceNotFoundException;
 import com.beour.global.exception.exceptionType.UserNotFoundException;
 import com.beour.reservation.host.dto.CalendarReservationResponseDto;
 import com.beour.reservation.commons.entity.Reservation;
 import com.beour.reservation.commons.enums.ReservationStatus;
 import com.beour.reservation.commons.repository.ReservationRepository;
+import com.beour.space.domain.entity.Space;
+import com.beour.space.domain.repository.SpaceRepository;
 import com.beour.user.entity.User;
 import com.beour.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -21,32 +24,67 @@ public class ReservationCalendarService {
 
     private final ReservationRepository reservationRepository;
     private final UserRepository userRepository;
+    private final SpaceRepository spaceRepository;
 
-    public List<CalendarReservationResponseDto> getHostCalendarReservations(LocalDate date) {
+    public List<CalendarReservationResponseDto> getHostCalendarReservations(LocalDate date, Long spaceId) {
         User host = findUserFromToken();
 
-        List<Reservation> reservationList = reservationRepository.findByHostIdAndDateAndDeletedAtIsNull(
-                host.getId(), date);
+        List<Reservation> reservationList;
+
+        if (spaceId != null) {
+            validateSpaceOwnership(host, spaceId);
+            reservationList = reservationRepository.findByHostIdAndDateAndSpaceIdAndDeletedAtIsNull(
+                    host.getId(), date, spaceId);
+        } else {
+            reservationList = reservationRepository.findByHostIdAndDateAndDeletedAtIsNull(
+                    host.getId(), date);
+        }
 
         return convertToCalendarResponseDto(reservationList);
     }
 
-    public List<CalendarReservationResponseDto> getHostPendingReservations(LocalDate date) {
+    public List<CalendarReservationResponseDto> getHostPendingReservations(LocalDate date, Long spaceId) {
         User host = findUserFromToken();
 
-        List<Reservation> reservationList = reservationRepository.findByHostIdAndDateAndStatusAndDeletedAtIsNull(
-                host.getId(), date, ReservationStatus.PENDING);
+        List<Reservation> reservationList;
+
+        if (spaceId != null) {
+            validateSpaceOwnership(host, spaceId);
+            reservationList = reservationRepository.findByHostIdAndDateAndSpaceIdAndStatusAndDeletedAtIsNull(
+                    host.getId(), date, spaceId, ReservationStatus.PENDING);
+        } else {
+            reservationList = reservationRepository.findByHostIdAndDateAndStatusAndDeletedAtIsNull(
+                    host.getId(), date, ReservationStatus.PENDING);
+        }
 
         return convertToCalendarResponseDto(reservationList);
     }
 
-    public List<CalendarReservationResponseDto> getHostAcceptedReservations(LocalDate date) {
+    public List<CalendarReservationResponseDto> getHostAcceptedReservations(LocalDate date, Long spaceId) {
         User host = findUserFromToken();
 
-        List<Reservation> reservationList = reservationRepository.findByHostIdAndDateAndStatusAndDeletedAtIsNull(
-                host.getId(), date, ReservationStatus.ACCEPTED);
+        List<Reservation> reservationList;
+
+        if (spaceId != null) {
+            validateSpaceOwnership(host, spaceId);
+            reservationList = reservationRepository.findByHostIdAndDateAndSpaceIdAndStatusAndDeletedAtIsNull(
+                    host.getId(), date, spaceId, ReservationStatus.ACCEPTED);
+        } else {
+            reservationList = reservationRepository.findByHostIdAndDateAndStatusAndDeletedAtIsNull(
+                    host.getId(), date, ReservationStatus.ACCEPTED);
+        }
 
         return convertToCalendarResponseDto(reservationList);
+    }
+
+    private void validateSpaceOwnership(User host, Long spaceId) {
+        Space space = spaceRepository.findById(spaceId).orElseThrow(
+                () -> new SpaceNotFoundException("존재하지 않는 공간입니다.")
+        );
+
+        if (!space.getHost().getId().equals(host.getId())) {
+            throw new IllegalArgumentException("해당 공간의 소유자가 아닙니다.");
+        }
     }
 
     private List<CalendarReservationResponseDto> convertToCalendarResponseDto(List<Reservation> reservationList) {


### PR DESCRIPTION
## ❗ Issue
[#76] 호스트 예약캘린더 - 날짜별 예약 확인 및 필터링

## ✨ 구현한 기능
- [GET] 1) 클라이언트로부터 host_id, date를 받아서 host_id에 해당하는 예약 데이터(resercvation_id, guest의 name, reservation status,  space의 name, 예약 startTime, 예약 endTime, guestCount) 리스트를 서버로부터 응답받는 API.
- [GET] 2) 클라이언트로부터 host_id, date를 받아서 host_id에 해당하고 reservation status가 PENDING인 예약 데이터(resercvation_id, guest의 name, reservation status, space의 name, 예약 startTime, 예약 endTime, guestCount) 리스트를 서버로부터 응답받는 API.
- [GET] 3) 클라이언트로부터 host_id, date를 받아서 host_id에 해당하고 reservation status가 ACCEPTED인 예약 데이터(resercvation_id, guest의 name, reservation status, space의 name, 예약 startTime, 예약 endTime, guestCount) 리스트를 서버로부터 응답받는 API.
- 4. 1~3번 기능에 space_id를 받았다면(받지 않는 케이스도 있음) space_id에 해당하는 reservation을 필터링해주는 기능을 추가

![image](https://github.com/user-attachments/assets/eb4fb276-9891-4964-8e4b-0c58bfd435bf)