### PR TITLE
[BE] 호스트 - 답글(ReviewComment) CUD API를 구현한다.

### DIFF
--- a/src/main/java/com/beour/review/domain/entity/Review.java
+++ b/src/main/java/com/beour/review/domain/entity/Review.java
@@ -8,6 +8,7 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -55,4 +56,7 @@ public class Review extends BaseTimeEntity {
         this.rating = rating;
     }
 
+    public void softDelete() {
+        super.softDelete();
+    }
 }

--- a/src/main/java/com/beour/review/domain/entity/Review.java
+++ b/src/main/java/com/beour/review/domain/entity/Review.java
@@ -8,7 +8,6 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -54,9 +53,5 @@ public class Review extends BaseTimeEntity {
 
     public void updateRating(int rating) {
         this.rating = rating;
-    }
-
-    public void softDelete() {
-        super.softDelete();
     }
 }

--- a/src/main/java/com/beour/review/domain/entity/ReviewComment.java
+++ b/src/main/java/com/beour/review/domain/entity/ReviewComment.java
@@ -5,8 +5,6 @@ import com.beour.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.time.LocalDate;
-
 @Entity
 @Getter
 @NoArgsConstructor
@@ -32,5 +30,4 @@ public class ReviewComment extends BaseTimeEntity {
     public void updateContent(String content) {
         this.content = content;
     }
-
 }

--- a/src/main/java/com/beour/review/guest/controller/ReviewGuestController.java
+++ b/src/main/java/com/beour/review/guest/controller/ReviewGuestController.java
@@ -1,12 +1,15 @@
 package com.beour.review.guest.controller;
 
 import com.beour.global.response.ApiResponse;
+import com.beour.review.guest.dto.ReviewDetailResponseDto;
+import com.beour.review.guest.dto.ReviewForReservationResponseDto;
+import com.beour.review.guest.dto.ReviewRequestDto;
+import com.beour.review.guest.dto.ReviewUpdateRequestDto;
 import com.beour.review.guest.dto.ReviewableReservationResponseDto;
 import com.beour.review.guest.dto.WrittenReviewResponseDto;
 import com.beour.review.guest.service.ReviewGuestService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -24,5 +27,35 @@ public class ReviewGuestController {
     @GetMapping("/api/guest/reviews/written")
     public ApiResponse<List<WrittenReviewResponseDto>> getWrittenReviews() {
         return ApiResponse.ok(reviewGuestService.getWrittenReviews());
+    }
+
+    // 예약 정보 조회 (리뷰 작성을 위한)
+    @GetMapping("/api/guest/reviews/reservation/{reservationId}")
+    public ApiResponse<ReviewForReservationResponseDto> getReservationForReview(@PathVariable Long reservationId) {
+        return ApiResponse.ok(reviewGuestService.getReservationForReview(reservationId));
+    }
+
+    @PostMapping("/api/guest/reviews")
+    public ApiResponse<String> createReview(@RequestBody ReviewRequestDto requestDto) {
+        reviewGuestService.createReview(requestDto);
+        return ApiResponse.ok("Review가 저장되었습니다.");
+    }
+
+    // 리뷰 상세 조회
+    @GetMapping("/api/guest/reviews/{reviewId}")
+    public ApiResponse<ReviewDetailResponseDto> getReviewDetail(@PathVariable Long reviewId) {
+        return ApiResponse.ok(reviewGuestService.getReviewDetail(reviewId));
+    }
+
+    @PatchMapping("/api/guest/reviews/{reviewId}")
+    public ApiResponse<String> updateReview(@PathVariable Long reviewId, @RequestBody ReviewUpdateRequestDto requestDto) {
+        reviewGuestService.updateReview(reviewId, requestDto);
+        return ApiResponse.ok("Review가 수정되었습니다.");
+    }
+
+    @DeleteMapping("/api/guest/reviews/{reviewId}")
+    public ApiResponse<String> deleteReview(@PathVariable Long reviewId) {
+        reviewGuestService.deleteReview(reviewId);
+        return ApiResponse.ok("Review가 삭제되었습니다.");
     }
 }

--- a/src/main/java/com/beour/review/guest/dto/ReviewDetailResponseDto.java
+++ b/src/main/java/com/beour/review/guest/dto/ReviewDetailResponseDto.java
@@ -1,0 +1,42 @@
+package com.beour.review.guest.dto;
+
+import com.beour.review.domain.entity.Review;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ReviewDetailResponseDto {
+    private Long reviewId;
+    private int rating;
+    private String content;
+    private LocalDate reservedDate;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private List<String> imageUrls;
+
+    public static ReviewDetailResponseDto of(Review review) {
+        List<String> imageUrls = review.getImages().stream()
+                .map(image -> image.getImageUrl())
+                .collect(Collectors.toList());
+
+        return ReviewDetailResponseDto.builder()
+                .reviewId(review.getId())
+                .rating(review.getRating())
+                .content(review.getContent())
+                .reservedDate(review.getReservedDate())
+                .createdAt(review.getCreatedAt())
+                .updatedAt(review.getUpdatedAt())
+                .imageUrls(imageUrls)
+                .build();
+    }
+}

--- a/src/main/java/com/beour/review/guest/dto/ReviewForReservationResponseDto.java
+++ b/src/main/java/com/beour/review/guest/dto/ReviewForReservationResponseDto.java
@@ -1,0 +1,37 @@
+package com.beour.review.guest.dto;
+
+import com.beour.reservation.commons.entity.Reservation;
+import com.beour.reservation.commons.enums.UsagePurpose;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ReviewForReservationResponseDto {
+    private Long reservationId;
+    private String spaceName;
+    private LocalDate date;
+    private LocalTime startTime;
+    private LocalTime endTime;
+    private int guestCount;
+    private UsagePurpose usagePurpose;
+
+    public static ReviewForReservationResponseDto of(Reservation reservation) {
+        return ReviewForReservationResponseDto.builder()
+                .reservationId(reservation.getId())
+                .spaceName(reservation.getSpace().getName())
+                .date(reservation.getDate())
+                .startTime(reservation.getStartTime())
+                .endTime(reservation.getEndTime())
+                .guestCount(reservation.getGuestCount())
+                .usagePurpose(reservation.getUsagePurpose())
+                .build();
+    }
+}

--- a/src/main/java/com/beour/review/guest/dto/ReviewRequestDto.java
+++ b/src/main/java/com/beour/review/guest/dto/ReviewRequestDto.java
@@ -1,0 +1,17 @@
+package com.beour.review.guest.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReviewRequestDto {
+    private Long reservationId;
+    private int rating;
+    private String content;
+    private List<String> imageUrls;
+}

--- a/src/main/java/com/beour/review/guest/dto/ReviewUpdateRequestDto.java
+++ b/src/main/java/com/beour/review/guest/dto/ReviewUpdateRequestDto.java
@@ -1,0 +1,16 @@
+package com.beour.review.guest.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReviewUpdateRequestDto {
+    private int rating;
+    private String content;
+    private List<String> imageUrls;
+}

--- a/src/main/java/com/beour/review/guest/service/ReviewGuestService.java
+++ b/src/main/java/com/beour/review/guest/service/ReviewGuestService.java
@@ -3,10 +3,17 @@ package com.beour.review.guest.service;
 import com.beour.global.exception.exceptionType.UserNotFoundException;
 import com.beour.reservation.commons.entity.Reservation;
 import com.beour.reservation.commons.enums.ReservationStatus;
+import com.beour.reservation.commons.exceptionType.ReservationNotFound;
 import com.beour.reservation.commons.repository.ReservationRepository;
 import com.beour.review.domain.entity.Review;
 import com.beour.review.domain.entity.ReviewComment;
+import com.beour.review.domain.entity.ReviewImage;
+import com.beour.review.domain.repository.ReviewImageRepository;
 import com.beour.review.domain.repository.ReviewRepository;
+import com.beour.review.guest.dto.ReviewDetailResponseDto;
+import com.beour.review.guest.dto.ReviewForReservationResponseDto;
+import com.beour.review.guest.dto.ReviewRequestDto;
+import com.beour.review.guest.dto.ReviewUpdateRequestDto;
 import com.beour.review.guest.dto.ReviewableReservationResponseDto;
 import com.beour.review.guest.dto.WrittenReviewResponseDto;
 import com.beour.user.entity.User;
@@ -14,6 +21,7 @@ import com.beour.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -24,6 +32,7 @@ public class ReviewGuestService {
 
     private final ReservationRepository reservationRepository;
     private final ReviewRepository reviewRepository;
+    private final ReviewImageRepository reviewImageRepository;
     private final UserRepository userRepository;
 
     public List<ReviewableReservationResponseDto> getReviewableReservations() {
@@ -60,11 +69,126 @@ public class ReviewGuestService {
                 .collect(Collectors.toList());
     }
 
+    // 예약 정보 조회 (리뷰 작성을 위한)
+    public ReviewForReservationResponseDto getReservationForReview(Long reservationId) {
+        User guest = findUserFromToken();
+        Reservation reservation = findReservationById(reservationId);
+
+        validateReservationOwner(reservation, guest);
+
+        return ReviewForReservationResponseDto.of(reservation);
+    }
+
+    @Transactional
+    public void createReview(ReviewRequestDto requestDto) {
+        User guest = findUserFromToken();
+        Reservation reservation = findReservationById(requestDto.getReservationId());
+
+        validateReservationOwner(reservation, guest);
+
+        // 이미 리뷰가 작성되었는지 확인
+        if (reviewRepository.findByGuestIdAndSpaceIdAndReservedDateAndDeletedAtIsNull(
+                guest.getId(), reservation.getSpace().getId(), reservation.getDate()).isPresent()) {
+            throw new IllegalArgumentException("이미 해당 예약에 대한 리뷰가 작성되었습니다.");
+        }
+
+        Review review = Review.builder()
+                .guest(guest)
+                .space(reservation.getSpace())
+                .reservation(reservation)
+                .rating(requestDto.getRating())
+                .content(requestDto.getContent())
+                .reservedDate(reservation.getDate())
+                .build();
+
+        Review savedReview = reviewRepository.save(review);
+
+        saveReviewImages(savedReview, requestDto.getImageUrls());
+    }
+
+    public ReviewDetailResponseDto getReviewDetail(Long reviewId) {
+        User guest = findUserFromToken();
+        Review review = findReviewById(reviewId);
+
+        validateReviewOwner(review, guest);
+
+        return ReviewDetailResponseDto.of(review);
+    }
+
+    @Transactional
+    public void updateReview(Long reviewId, ReviewUpdateRequestDto requestDto) {
+        User guest = findUserFromToken();
+        Review review = findReviewById(reviewId);
+
+        validateReviewOwner(review, guest);
+
+        // 리뷰 업데이트
+        review.updateRating(requestDto.getRating());
+        review.updateContent(requestDto.getContent());
+
+        // 기존 이미지 삭제 후 새로운 이미지 저장
+        deleteExistingImages(review);
+        saveReviewImages(review, requestDto.getImageUrls());
+    }
+
+    @Transactional
+    public void deleteReview(Long reviewId) {
+        User guest = findUserFromToken();
+        Review review = findReviewById(reviewId);
+
+        validateReviewOwner(review, guest);
+
+        review.softDelete();
+    }
+
     private User findUserFromToken() {
         String loginId = SecurityContextHolder.getContext().getAuthentication().getName();
-
         return userRepository.findByLoginIdAndDeletedAtIsNull(loginId).orElseThrow(
                 () -> new UserNotFoundException("해당 유저를 찾을 수 없습니다.")
         );
+    }
+
+    private Reservation findReservationById(Long reservationId) {
+        return reservationRepository.findById(reservationId).orElseThrow(
+                () -> new ReservationNotFound("해당 예약을 찾을 수 없습니다.")
+        );
+    }
+
+    private Review findReviewById(Long reviewId) {
+        return reviewRepository.findById(reviewId).orElseThrow(
+                () -> new RuntimeException("해당 리뷰를 찾을 수 없습니다.")
+        );
+    }
+
+    private void validateReservationOwner(Reservation reservation, User guest) {
+        if (!reservation.getGuest().getId().equals(guest.getId())) {
+            throw new IllegalArgumentException("해당 예약에 대한 권한이 없습니다.");
+        }
+    }
+
+    private void validateReviewOwner(Review review, User guest) {
+        if (!review.getGuest().getId().equals(guest.getId())) {
+            throw new IllegalArgumentException("해당 리뷰에 대한 권한이 없습니다.");
+        }
+    }
+
+    private void saveReviewImages(Review review, List<String> imageUrls) {
+        if (imageUrls != null && !imageUrls.isEmpty()) {
+            List<ReviewImage> images = imageUrls.stream()
+                    .map(url -> ReviewImage.builder()
+                            .review(review)
+                            .imageUrl(url)
+                            .build())
+                    .collect(Collectors.toList());
+
+            reviewImageRepository.saveAll(images);
+        }
+    }
+
+    private void deleteExistingImages(Review review) {
+        List<ReviewImage> existingImages = review.getImages();
+        if (!existingImages.isEmpty()) {
+            reviewImageRepository.deleteAll(existingImages);
+        }
     }
 }

--- a/src/main/java/com/beour/review/host/controller/ReviewCommentHostController.java
+++ b/src/main/java/com/beour/review/host/controller/ReviewCommentHostController.java
@@ -6,6 +6,7 @@ import com.beour.review.host.dto.ReviewCommentResponseDto;
 import com.beour.review.host.dto.ReviewCommentUpdateRequestDto;
 import com.beour.review.host.dto.ReviewCommentableResponseDto;
 import com.beour.review.host.service.ReviewCommentHostService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -28,14 +29,14 @@ public class ReviewCommentHostController {
     }
 
     @PostMapping("/api/host/review-comments")
-    public ApiResponse<String> createReviewComment(@RequestBody ReviewCommentCreateRequestDto requestDto) {
+    public ApiResponse<String> createReviewComment(@RequestBody @Valid ReviewCommentCreateRequestDto requestDto) {
         reviewCommentHostService.createReviewComment(requestDto);
         return ApiResponse.ok("답글이 저장되었습니다.");
     }
 
     @PatchMapping("/api/host/review-comments/{commentId}")
     public ApiResponse<String> updateReviewComment(@PathVariable Long commentId,
-                                                 @RequestBody ReviewCommentUpdateRequestDto requestDto) {
+                                                 @RequestBody @Valid ReviewCommentUpdateRequestDto requestDto) {
         reviewCommentHostService.updateReviewComment(commentId, requestDto);
         return ApiResponse.ok("답글이 수정되었습니다.");
     }

--- a/src/main/java/com/beour/review/host/controller/ReviewCommentHostController.java
+++ b/src/main/java/com/beour/review/host/controller/ReviewCommentHostController.java
@@ -1,7 +1,9 @@
 package com.beour.review.host.controller;
 
 import com.beour.global.response.ApiResponse;
+import com.beour.review.host.dto.ReviewCommentCreateRequestDto;
 import com.beour.review.host.dto.ReviewCommentResponseDto;
+import com.beour.review.host.dto.ReviewCommentUpdateRequestDto;
 import com.beour.review.host.dto.ReviewCommentableResponseDto;
 import com.beour.review.host.service.ReviewCommentHostService;
 import lombok.RequiredArgsConstructor;
@@ -23,5 +25,24 @@ public class ReviewCommentHostController {
     @GetMapping("/api/host/review-comments/written")
     public ApiResponse<List<ReviewCommentResponseDto>> getWrittenReviewComments() {
         return ApiResponse.ok(reviewCommentHostService.getWrittenReviewComments());
+    }
+
+    @PostMapping("/api/host/review-comments")
+    public ApiResponse<String> createReviewComment(@RequestBody ReviewCommentCreateRequestDto requestDto) {
+        reviewCommentHostService.createReviewComment(requestDto);
+        return ApiResponse.ok("답글이 저장되었습니다.");
+    }
+
+    @PatchMapping("/api/host/review-comments/{commentId}")
+    public ApiResponse<String> updateReviewComment(@PathVariable Long commentId,
+                                                 @RequestBody ReviewCommentUpdateRequestDto requestDto) {
+        reviewCommentHostService.updateReviewComment(commentId, requestDto);
+        return ApiResponse.ok("답글이 수정되었습니다.");
+    }
+
+    @DeleteMapping("/api/host/review-comments/{commentId}")
+    public ApiResponse<String> deleteReviewComment(@PathVariable Long commentId) {
+        reviewCommentHostService.deleteReviewComment(commentId);
+        return ApiResponse.ok("답글이 삭제되었습니다.");
     }
 }

--- a/src/main/java/com/beour/review/host/controller/ReviewCommentHostController.java
+++ b/src/main/java/com/beour/review/host/controller/ReviewCommentHostController.java
@@ -1,0 +1,27 @@
+package com.beour.review.host.controller;
+
+import com.beour.global.response.ApiResponse;
+import com.beour.review.host.dto.ReviewCommentResponseDto;
+import com.beour.review.host.dto.ReviewCommentableResponseDto;
+import com.beour.review.host.service.ReviewCommentHostService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@RestController
+public class ReviewCommentHostController {
+
+    private final ReviewCommentHostService reviewCommentHostService;
+
+    @GetMapping("/api/host/review-comments/commentable")
+    public ApiResponse<List<ReviewCommentableResponseDto>> getCommentableReviews() {
+        return ApiResponse.ok(reviewCommentHostService.getCommentableReviews());
+    }
+
+    @GetMapping("/api/host/review-comments/written")
+    public ApiResponse<List<ReviewCommentResponseDto>> getWrittenReviewComments() {
+        return ApiResponse.ok(reviewCommentHostService.getWrittenReviewComments());
+    }
+}

--- a/src/main/java/com/beour/review/host/dto/ReviewCommentCreateRequestDto.java
+++ b/src/main/java/com/beour/review/host/dto/ReviewCommentCreateRequestDto.java
@@ -1,0 +1,14 @@
+package com.beour.review.host.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReviewCommentCreateRequestDto {
+
+    private Long reviewId;
+    private String content;
+}

--- a/src/main/java/com/beour/review/host/dto/ReviewCommentCreateRequestDto.java
+++ b/src/main/java/com/beour/review/host/dto/ReviewCommentCreateRequestDto.java
@@ -1,5 +1,7 @@
 package com.beour.review.host.dto;
 
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,6 +11,9 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class ReviewCommentCreateRequestDto {
 
+    @NotNull(message = "reviewId는 필수입니다.")
     private Long reviewId;
+
+    @NotBlank(message = "답글 내용은 비어 있을 수 없습니다.")
     private String content;
 }

--- a/src/main/java/com/beour/review/host/dto/ReviewCommentResponseDto.java
+++ b/src/main/java/com/beour/review/host/dto/ReviewCommentResponseDto.java
@@ -1,0 +1,48 @@
+package com.beour.review.host.dto;
+
+import com.beour.review.domain.entity.Review;
+import com.beour.review.domain.entity.ReviewComment;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ReviewCommentResponseDto {
+
+    private String guestNickname;
+    private int reviewRating;
+    private LocalDateTime reviewCreatedAt;
+    private String spaceName;
+    private LocalDate reservationDate;
+    private String reviewContent;
+    private List<String> reviewImages;
+    private String hostNickname;
+    private LocalDateTime reviewCommentCreatedAt;
+    private String reviewCommentContent;
+
+    public static ReviewCommentResponseDto of(Review review, ReviewComment reviewComment) {
+        return ReviewCommentResponseDto.builder()
+                .guestNickname(review.getGuest().getNickname())
+                .reviewRating(review.getRating())
+                .reviewCreatedAt(review.getCreatedAt())
+                .spaceName(review.getSpace().getName())
+                .reservationDate(review.getReservedDate())
+                .reviewContent(review.getContent())
+                .reviewImages(review.getImages().stream()
+                        .map(reviewImage -> reviewImage.getImageUrl())
+                        .collect(Collectors.toList()))
+                .hostNickname(reviewComment.getUser().getNickname())
+                .reviewCommentCreatedAt(reviewComment.getCreatedAt())
+                .reviewCommentContent(reviewComment.getContent())
+                .build();
+    }
+}

--- a/src/main/java/com/beour/review/host/dto/ReviewCommentUpdateRequestDto.java
+++ b/src/main/java/com/beour/review/host/dto/ReviewCommentUpdateRequestDto.java
@@ -1,5 +1,6 @@
 package com.beour.review.host.dto;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,5 +10,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class ReviewCommentUpdateRequestDto {
 
+    @NotBlank(message = "답글 내용은 비어 있을 수 없습니다.")
     private String content;
 }

--- a/src/main/java/com/beour/review/host/dto/ReviewCommentUpdateRequestDto.java
+++ b/src/main/java/com/beour/review/host/dto/ReviewCommentUpdateRequestDto.java
@@ -1,0 +1,13 @@
+package com.beour.review.host.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ReviewCommentUpdateRequestDto {
+
+    private String content;
+}

--- a/src/main/java/com/beour/review/host/dto/ReviewCommentableResponseDto.java
+++ b/src/main/java/com/beour/review/host/dto/ReviewCommentableResponseDto.java
@@ -1,0 +1,43 @@
+package com.beour.review.host.dto;
+
+import com.beour.review.domain.entity.Review;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ReviewCommentableResponseDto {
+
+    private Long reviewId;
+    private String guestNickname;
+    private int reviewRating;
+    private LocalDateTime reviewCreatedAt;
+    private String spaceName;
+    private LocalDate reservationDate;
+    private String reviewContent;
+    private List<String> reviewImages;
+
+    public static ReviewCommentableResponseDto of(Review review) {
+        return ReviewCommentableResponseDto.builder()
+                .reviewId(review.getId())
+                .guestNickname(review.getGuest().getNickname())
+                .reviewRating(review.getRating())
+                .reviewCreatedAt(review.getCreatedAt())
+                .spaceName(review.getSpace().getName())
+                .reservationDate(review.getReservedDate())
+                .reviewContent(review.getContent())
+                .reviewImages(review.getImages().stream()
+                        .map(reviewImage -> reviewImage.getImageUrl())
+                        .collect(Collectors.toList()))
+                .build();
+    }
+}

--- a/src/main/java/com/beour/review/host/service/ReviewCommentHostService.java
+++ b/src/main/java/com/beour/review/host/service/ReviewCommentHostService.java
@@ -1,0 +1,63 @@
+package com.beour.review.host.service;
+
+import com.beour.global.exception.exceptionType.UserNotFoundException;
+import com.beour.review.domain.entity.Review;
+import com.beour.review.domain.entity.ReviewComment;
+import com.beour.review.domain.repository.ReviewCommentRepository;
+import com.beour.review.domain.repository.ReviewRepository;
+import com.beour.review.host.dto.ReviewCommentResponseDto;
+import com.beour.review.host.dto.ReviewCommentableResponseDto;
+import com.beour.user.entity.User;
+import com.beour.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@RequiredArgsConstructor
+@Service
+public class ReviewCommentHostService {
+
+    private final ReviewRepository reviewRepository;
+    private final ReviewCommentRepository reviewCommentRepository;
+    private final UserRepository userRepository;
+
+    public List<ReviewCommentableResponseDto> getCommentableReviews() {
+        User host = findUserFromToken();
+
+        // 호스트가 소유한 공간에 대한 리뷰 중 댓글이 없는 리뷰 조회
+        List<Review> commentableReviews = reviewRepository.findAll()
+                .stream()
+                .filter(review -> review.getSpace().getHost().getId().equals(host.getId()))
+                .filter(review -> review.getDeletedAt() == null)
+                .filter(review -> review.getComment() == null)
+                .collect(Collectors.toList());
+
+        return commentableReviews.stream()
+                .map(ReviewCommentableResponseDto::of)
+                .collect(Collectors.toList());
+    }
+
+    public List<ReviewCommentResponseDto> getWrittenReviewComments() {
+        User host = findUserFromToken();
+
+        // 호스트가 작성한 리뷰 댓글 조회
+        List<ReviewComment> writtenComments = reviewCommentRepository.findAll()
+                .stream()
+                .filter(comment -> comment.getUser().getId().equals(host.getId()))
+                .filter(comment -> comment.getDeletedAt() == null)
+                .collect(Collectors.toList());
+
+        return writtenComments.stream()
+                .map(comment -> ReviewCommentResponseDto.of(comment.getReview(), comment))
+                .collect(Collectors.toList());
+    }
+
+    private User findUserFromToken() {
+        String loginId = SecurityContextHolder.getContext().getAuthentication().getName();
+        return userRepository.findByLoginIdAndDeletedAtIsNull(loginId)
+                .orElseThrow(() -> new UserNotFoundException("해당 유저를 찾을 수 없습니다."));
+    }
+}

--- a/src/main/java/com/beour/review/host/service/ReviewCommentHostService.java
+++ b/src/main/java/com/beour/review/host/service/ReviewCommentHostService.java
@@ -5,13 +5,16 @@ import com.beour.review.domain.entity.Review;
 import com.beour.review.domain.entity.ReviewComment;
 import com.beour.review.domain.repository.ReviewCommentRepository;
 import com.beour.review.domain.repository.ReviewRepository;
+import com.beour.review.host.dto.ReviewCommentCreateRequestDto;
 import com.beour.review.host.dto.ReviewCommentResponseDto;
+import com.beour.review.host.dto.ReviewCommentUpdateRequestDto;
 import com.beour.review.host.dto.ReviewCommentableResponseDto;
 import com.beour.user.entity.User;
 import com.beour.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -55,9 +58,72 @@ public class ReviewCommentHostService {
                 .collect(Collectors.toList());
     }
 
+    @Transactional
+    public void createReviewComment(ReviewCommentCreateRequestDto requestDto) {
+        User host = findUserFromToken();
+        Review review = findReviewById(requestDto.getReviewId());
+
+        validateHostOwnership(host, review);
+
+        // 이미 댓글이 있는지 확인
+        if (review.getComment() != null) {
+            throw new IllegalArgumentException("이미 댓글이 작성된 리뷰입니다.");
+        }
+
+        ReviewComment reviewComment = ReviewComment.builder()
+                .user(host)
+                .review(review)
+                .content(requestDto.getContent())
+                .build();
+
+        reviewCommentRepository.save(reviewComment);
+    }
+
+    @Transactional
+    public void updateReviewComment(Long commentId, ReviewCommentUpdateRequestDto requestDto) {
+        User host = findUserFromToken();
+        ReviewComment reviewComment = findReviewCommentById(commentId);
+
+        // 호스트가 해당 댓글의 작성자인지 확인
+        if (!reviewComment.getUser().getId().equals(host.getId())) {
+            throw new IllegalArgumentException("댓글 수정 권한이 없습니다.");
+        }
+
+        reviewComment.updateContent(requestDto.getContent());
+    }
+
+    @Transactional
+    public void deleteReviewComment(Long commentId) {
+        User host = findUserFromToken();
+        ReviewComment reviewComment = findReviewCommentById(commentId);
+
+        // 호스트가 해당 댓글의 작성자인지 확인
+        if (!reviewComment.getUser().getId().equals(host.getId())) {
+            throw new IllegalArgumentException("댓글 삭제 권한이 없습니다.");
+        }
+
+        reviewComment.softDelete();
+    }
+
     private User findUserFromToken() {
         String loginId = SecurityContextHolder.getContext().getAuthentication().getName();
         return userRepository.findByLoginIdAndDeletedAtIsNull(loginId)
                 .orElseThrow(() -> new UserNotFoundException("해당 유저를 찾을 수 없습니다."));
+    }
+
+    private Review findReviewById(Long reviewId) {
+        return reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new RuntimeException("존재하지 않는 리뷰입니다."));
+    }
+
+    private ReviewComment findReviewCommentById(Long commentId) {
+        return reviewCommentRepository.findById(commentId)
+                .orElseThrow(() -> new RuntimeException("존재하지 않는 댓글입니다."));
+    }
+
+    private void validateHostOwnership(User host, Review review) {
+        if (!review.getSpace().getHost().getId().equals(host.getId())) {
+            throw new IllegalArgumentException("해당 리뷰의 공간 소유자가 아닙니다.");
+        }
     }
 }


### PR DESCRIPTION
## ISSUE
[#85] 호스트 - 호스트 - 답글(ReviewComment) CUD API

## 추가된 API 목록
### 1. 클라이언트로부터 review_id, host_id(user_id의 경우는 ReservationHostController/Service코드처럼 토큰으로 사용자의 user_id를 뽑아올 수 있도록 해주세요.), content를 받으면 DB에 저장하는 API.
### 2. 클라이언트로부터 reviewComment_id, content를 받아 수정하는 PATCH API
### 3. 클라이언트로부터 reviewComment_id를 받으면 해당하는 review를 삭제하는 API(soft delete)
