### PR TITLE
[BE] 내공간 리스트 조회 API를 구현한다.

### DIFF
--- a/src/main/java/com/beour/review/domain/repository/ReviewRepository.java
+++ b/src/main/java/com/beour/review/domain/repository/ReviewRepository.java
@@ -9,4 +9,5 @@ import java.util.Optional;
 public interface ReviewRepository extends JpaRepository<Review, Long> {
     Optional<Review> findByGuestIdAndSpaceIdAndReservedDateAndDeletedAtIsNull(Long guestId, Long spaceId, LocalDate reservedDate);
 
+    long countBySpaceIdAndDeletedAtIsNull(Long spaceId);
 }

--- a/src/main/java/com/beour/space/host/controller/SpaceController.java
+++ b/src/main/java/com/beour/space/host/controller/SpaceController.java
@@ -1,6 +1,7 @@
 package com.beour.space.host.controller;
 
 import com.beour.global.response.ApiResponse;
+import com.beour.space.host.dto.HostMySpaceListResponseDto;
 import com.beour.space.host.dto.SpaceDetailResponseDto;
 import com.beour.space.host.dto.SpaceRegisterRequestDto;
 import com.beour.space.host.dto.SpaceUpdateRequestDto;
@@ -9,6 +10,8 @@ import com.beour.space.host.service.SpaceService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -31,6 +34,11 @@ public class SpaceController {
     @GetMapping("/{id}")
     public ApiResponse<SpaceDetailResponseDto> getDetailInfo(@PathVariable Long id) {
         return ApiResponse.ok(spaceService.getDetailedSpaceInfo(id));
+    }
+
+    @GetMapping("/my-spaces")
+    public ApiResponse<List<HostMySpaceListResponseDto>> getMySpaces() {
+        return ApiResponse.ok(spaceService.getMySpaces());
     }
 
     @PutMapping("/{id}")

--- a/src/main/java/com/beour/space/host/dto/HostMySpaceListResponseDto.java
+++ b/src/main/java/com/beour/space/host/dto/HostMySpaceListResponseDto.java
@@ -11,16 +11,18 @@ import lombok.NoArgsConstructor;
 @Builder
 public class HostMySpaceListResponseDto {
     private Long spaceId;
+    private String spaceName;
     private String address; // 동만 (ex. 삼성동, 염창동)
     private int maxCapacity;
     private Double avgRating;
     private long reviewCount;
     private String thumbnailUrl;
 
-    public static HostMySpaceListResponseDto of(Long spaceId, String address, int maxCapacity,
+    public static HostMySpaceListResponseDto of(Long spaceId, String spaceName, String address, int maxCapacity,
                                                 Double avgRating, long reviewCount, String thumbnailUrl) {
         return HostMySpaceListResponseDto.builder()
                 .spaceId(spaceId)
+                .spaceName(spaceName)
                 .address(address)
                 .maxCapacity(maxCapacity)
                 .avgRating(avgRating)

--- a/src/main/java/com/beour/space/host/dto/HostMySpaceListResponseDto.java
+++ b/src/main/java/com/beour/space/host/dto/HostMySpaceListResponseDto.java
@@ -1,0 +1,31 @@
+package com.beour.space.host.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class HostMySpaceListResponseDto {
+    private Long spaceId;
+    private String address; // 동만 (ex. 삼성동, 염창동)
+    private int maxCapacity;
+    private Double avgRating;
+    private long reviewCount;
+    private String thumbnailUrl;
+
+    public static HostMySpaceListResponseDto of(Long spaceId, String address, int maxCapacity,
+                                                Double avgRating, long reviewCount, String thumbnailUrl) {
+        return HostMySpaceListResponseDto.builder()
+                .spaceId(spaceId)
+                .address(address)
+                .maxCapacity(maxCapacity)
+                .avgRating(avgRating)
+                .reviewCount(reviewCount)
+                .thumbnailUrl(thumbnailUrl)
+                .build();
+    }
+}

--- a/src/main/java/com/beour/space/host/service/SpaceService.java
+++ b/src/main/java/com/beour/space/host/service/SpaceService.java
@@ -144,6 +144,7 @@ public class SpaceService {
                     long reviewCount = getReviewCountBySpaceId(space.getId());
                     return HostMySpaceListResponseDto.of(
                             space.getId(),
+                            space.getName(),
                             extractDongFromAddress(space.getAddress()),
                             space.getMaxCapacity(),
                             space.getAvgRating(),

--- a/src/main/java/com/beour/space/host/service/SpaceService.java
+++ b/src/main/java/com/beour/space/host/service/SpaceService.java
@@ -2,12 +2,10 @@ package com.beour.space.host.service;
 
 import com.beour.global.exception.exceptionType.SpaceNotFoundException;
 import com.beour.global.exception.exceptionType.UserNotFoundException;
+import com.beour.review.domain.repository.ReviewRepository;
 import com.beour.space.domain.entity.*;
 import com.beour.space.domain.repository.*;
-import com.beour.space.host.dto.SpaceDetailResponseDto;
-import com.beour.space.host.dto.SpaceRegisterRequestDto;
-import com.beour.space.host.dto.SpaceUpdateRequestDto;
-import com.beour.space.host.dto.SpaceSimpleResponseDto;
+import com.beour.space.host.dto.*;
 import com.beour.user.entity.User;
 import com.beour.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +25,7 @@ public class SpaceService {
     private final TagRepository tagRepository;
     private final SpaceImageRepository spaceImageRepository;
     private final UserRepository userRepository;
+    private final ReviewRepository reviewRepository;
     private final KakaoMapService kakaoMapService;
 
     @Transactional
@@ -101,12 +100,6 @@ public class SpaceService {
         );
     }
 
-    // 예: 서울시 강남구 역삼동 어딘가 123 -> 서울시 강남구 역삼동
-    private String extractDongFromAddress(String address) {
-        String[] parts = address.split(" ");
-        return parts.length >= 3 ? String.join(" ", parts[0], parts[1], parts[2]) : address;
-    }
-
     @Transactional(readOnly = true)
     public SpaceDetailResponseDto getDetailedSpaceInfo(Long spaceId) {
         Space space = spaceRepository.findByIdAndDeletedAtIsNull(spaceId)
@@ -134,6 +127,31 @@ public class SpaceService {
                 .tags(space.getTags().stream().map(Tag::getContents).toList())
                 .imageUrls(space.getSpaceImages().stream().map(SpaceImage::getImageUrl).toList())
                 .build();
+    }
+
+    @Transactional(readOnly = true)
+    public List<HostMySpaceListResponseDto> getMySpaces() {
+        User host = findUserFromToken();
+
+        List<Space> spaces = spaceRepository.findByHostAndDeletedAtIsNull(host);
+
+        if (spaces.isEmpty()) {
+            throw new RuntimeException("등록된 공간이 없습니다.");
+        }
+
+        return spaces.stream()
+                .map(space -> {
+                    long reviewCount = getReviewCountBySpaceId(space.getId());
+                    return HostMySpaceListResponseDto.of(
+                            space.getId(),
+                            extractDongFromAddress(space.getAddress()),
+                            space.getMaxCapacity(),
+                            space.getAvgRating(),
+                            reviewCount,
+                            space.getThumbnailUrl()
+                    );
+                })
+                .collect(Collectors.toList());
     }
 
     @Transactional
@@ -245,6 +263,21 @@ public class SpaceService {
     public void deleteSpace(Long spaceId) {
         Space space = findSpaceByIdAndCheckOwnership(spaceId);
         space.delete();
+    }
+
+    // 예: 서울시 강남구 역삼동 어딘가 123 -> 역삼동
+    private String extractDongFromAddress(String address) {
+        String[] parts = address.split(" ");
+        if (parts.length >= 3) {
+            String dong = parts[2];
+            // '동'이 포함되어 있으면 그대로 반환, 없으면 구까지만 반환
+            return dong.contains("동") ? dong : parts[1];
+        }
+        return address;
+    }
+
+    private long getReviewCountBySpaceId(Long spaceId) {
+        return reviewRepository.countBySpaceIdAndDeletedAtIsNull(spaceId);
     }
 
     private Space findSpaceByIdAndCheckOwnership(Long spaceId) {


### PR DESCRIPTION
## ISSUE
[#93] HOST Space 기능 리펙토링

## 구현 내용(뻔한 내용이라 안 읽어도 됩니다!)
### 1. DTO 생성
- `HostMySpaceListResponseDto`: 내공간 리스트 응답을 위한 DTO
- 필드: spaceId, address(동만), maxCapacity, avgRating, reviewCount, thumbnailUrl

### 2. 컨트롤러 추가
- `GET /api/spaces/my-spaces`: 내공간 리스트 조회 엔드포인트
- 토큰에서 사용자 정보를 추출하여 사용 (ReservationHostController와 동일한 방식)

### 3. 서비스 로직
- `getMySpaces()`: 내공간 리스트 조회 메소드
- 토큰에서 호스트 정보를 추출하여 해당 호스트의 공간들을 조회
- 각 공간에 대한 리뷰 개수를 계산

### 4. 공통 메소드 분리
- `extractDongFromAddress()`: 주소에서 동 정보만 추출하는 메소드
- `getReviewCountBySpaceId()`: 특정 공간의 리뷰 개수를 조회하는 메소드
- `findUserFromToken()`: 토큰에서 사용자 정보를 추출하는 메소드 (기존 코드 재사용)

### 5. Repository 메소드 추가
- `ReviewRepository.countBySpaceIdAndDeletedAtIsNull()`: soft delete되지 않은 리뷰 개수 조회
