### PR TITLE
[BE] 토큰 관련 로직들을 리팩터링 하고 테스트 코드를 추가한다.

### DIFF
--- a/src/main/java/com/beour/global/exception/error/errorcode/UserErrorCode.java
+++ b/src/main/java/com/beour/global/exception/error/errorcode/UserErrorCode.java
@@ -13,6 +13,9 @@ public enum UserErrorCode implements ErrorCode {
     LOGIN_ID_DUPLICATE(409, "이미 사용중인 아이디입니다."),
     NICKNAME_ID_DUPLICATE(409, "이미 사용중인 닉네임입니다."),
     USER_ROLE_MISMATCH(400, "역할이 일치하지 않습니다."),
+    ACCESS_TOKEN_EXPIRED(401, "access 토큰이 만료되었습니다."),
+    NOT_ACCESS_TOKEN(401, "access 토큰이 아닙니다."),
+    ACCESS_TOKEN_NOT_FOUND(404, "access 토큰이 존재하지 않습니다."),
     REFRESH_TOKEN_EXPIRED(401, "refresh 토큰이 만료되었습니다."),
     REFRESH_TOKEN_NOT_FOUND(404, "refresh 토큰이 존재하지 않습니다.");
 

--- a/src/main/java/com/beour/global/jwt/CustomLogoutFilter.java
+++ b/src/main/java/com/beour/global/jwt/CustomLogoutFilter.java
@@ -22,9 +22,7 @@ public class CustomLogoutFilter extends GenericFilterBean {
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
         throws IOException, ServletException {
-
         doFilter((HttpServletRequest) request, (HttpServletResponse) response, chain);
-
     }
 
     private void doFilter(HttpServletRequest request, HttpServletResponse response,
@@ -32,7 +30,7 @@ public class CustomLogoutFilter extends GenericFilterBean {
 
         //api 요청 올바른지 체크하는 로직
         String requestUri = request.getRequestURI();
-        if (!requestUri.matches("^\\/logout$")) {
+        if (!requestUri.matches("^\\/api\\/logout$")) {
 
             filterChain.doFilter(request, response);
             return;
@@ -58,6 +56,7 @@ public class CustomLogoutFilter extends GenericFilterBean {
             response.setStatus(HttpServletResponse.SC_BAD_REQUEST);
             return;
         }
+
         try {
             jwtUtil.isExpired(refresh);
         } catch (ExpiredJwtException e) {

--- a/src/main/java/com/beour/global/jwt/JWTFilter.java
+++ b/src/main/java/com/beour/global/jwt/JWTFilter.java
@@ -38,21 +38,21 @@ public class JWTFilter extends OncePerRequestFilter {
 
         //access토큰 없을 시 다음 필터로 넘김
         String accessToken = extractAccessToken(authorization);
-        if(accessToken == null || accessToken.isBlank()){
+        if (accessToken == null || accessToken.isBlank()) {
             filterChain.doFilter(request, response);
             return;
         }
 
         //토큰 만료 여부 확인, 토큰 만료시 다음 필터로 넘기지 않고 만료 여부 프론트로 전달
-        try{
+        try {
             jwtUtil.isExpired(accessToken);
-        } catch (ExpiredJwtException ex){
+        } catch (ExpiredJwtException ex) {
             writeErrorResponse(response, UserErrorCode.ACCESS_TOKEN_EXPIRED);
             return;
         }
 
         //token이 access token인지 확인, 아니면 프론트한테 알려줌
-        if(!"access".equals(jwtUtil.getCategory(accessToken))){
+        if (!"access".equals(jwtUtil.getCategory(accessToken))) {
             writeErrorResponse(response, UserErrorCode.NOT_ACCESS_TOKEN);
             return;
         }
@@ -76,7 +76,8 @@ public class JWTFilter extends OncePerRequestFilter {
     }
 
     //프론트한테 가독성 좋게 에러 코드와 메세지 보내는 response body 만드는 함수
-    private void writeErrorResponse(HttpServletResponse response, ErrorCode errorCode) throws IOException {
+    private void writeErrorResponse(HttpServletResponse response, ErrorCode errorCode)
+        throws IOException {
         response.setStatus(errorCode.getCode());
         response.setContentType("application/json");
         response.setCharacterEncoding("UTF-8");

--- a/src/main/java/com/beour/global/jwt/LoginFilter.java
+++ b/src/main/java/com/beour/global/jwt/LoginFilter.java
@@ -165,7 +165,8 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
         writeJsonResponse(response, errorBody);
     }
 
-    private void writeJsonResponse(HttpServletResponse response, Map<String, Object> body) throws IOException {
+    private void writeJsonResponse(HttpServletResponse response, Map<String, Object> body)
+        throws IOException {
         ObjectMapper objectMapper = new ObjectMapper();
         response.getWriter().write(objectMapper.writeValueAsString(body));
     }

--- a/src/main/java/com/beour/global/jwt/ManageCookie.java
+++ b/src/main/java/com/beour/global/jwt/ManageCookie.java
@@ -7,9 +7,8 @@ public class ManageCookie {
     public static Cookie createCookie(String key, String value){
         Cookie cookie = new Cookie(key, value);
         cookie.setMaxAge(24 * 60 * 60); //refresh와 값 같게
-        //todo : 운영 배포시에 아래 주석 활성화
-        //cookie.setSecure(true);
-        //cookie.setPath("/");
+        cookie.setSecure(true);
+        cookie.setPath("/");
         cookie.setHttpOnly(true);
 
         return cookie;

--- a/src/main/java/com/beour/global/jwt/ManageCookie.java
+++ b/src/main/java/com/beour/global/jwt/ManageCookie.java
@@ -4,7 +4,7 @@ import jakarta.servlet.http.Cookie;
 
 public class ManageCookie {
 
-    public static Cookie createCookie(String key, String value){
+    public static Cookie createCookie(String key, String value) {
         Cookie cookie = new Cookie(key, value);
         cookie.setMaxAge(24 * 60 * 60); //refresh와 값 같게
         cookie.setSecure(true);

--- a/src/main/java/com/beour/global/security/SecurityConfig.java
+++ b/src/main/java/com/beour/global/security/SecurityConfig.java
@@ -93,7 +93,7 @@ public class SecurityConfig {
                     .hasRole("HOST")
 
                     .requestMatchers("/api/mypage/**").hasAnyRole("HOST", "GUEST")
-                    .requestMatchers("/logout", "/api/token/reissue").hasAnyRole("HOST", "GUEST", "ADMIN")
+                    .requestMatchers("/api/logout", "/api/token/reissue").hasAnyRole("HOST", "GUEST", "ADMIN")
 //                    .anyRequest().authenticated()
                     .anyRequest().permitAll()
             );

--- a/src/main/java/com/beour/global/security/SecurityConfig.java
+++ b/src/main/java/com/beour/global/security/SecurityConfig.java
@@ -81,7 +81,8 @@ public class SecurityConfig {
             .authorizeHttpRequests((auth) -> auth
                     .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
                     .requestMatchers("/api/users/**", "/api/signup/**", "/api/login",
-                        "/api/users/find/loginId", "/api/users/reset/password").permitAll()
+                        "/api/users/find/loginId", "/api/users/reset/password", "/api/token/reissue")
+                    .permitAll()
                     .requestMatchers("/api/spaces/reserve/available-times", "/api/spaces/search/**",
                         "/api/spaces/new", "/api/reviews/new", "/api/banners").permitAll()
 //                    .requestMatchers("/admin").hasRole("ADMIN")
@@ -93,7 +94,7 @@ public class SecurityConfig {
                     .hasRole("HOST")
 
                     .requestMatchers("/api/mypage/**").hasAnyRole("HOST", "GUEST")
-                    .requestMatchers("/api/logout", "/api/token/reissue").hasAnyRole("HOST", "GUEST", "ADMIN")
+                    .requestMatchers("/api/logout").hasAnyRole("HOST", "GUEST", "ADMIN")
 //                    .anyRequest().authenticated()
                     .anyRequest().permitAll()
             );

--- a/src/main/java/com/beour/user/enums/TokenExpireTime.java
+++ b/src/main/java/com/beour/user/enums/TokenExpireTime.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum TokenExpireTime {
 
+    //todo : token 만료 시간
     //10분  1000L * 60 * 10
     ACCESS_TOKEN_EXPIRATION_MILLIS(1000L * 60, "access token 만료 시간"),
     //1일  1000L * 60 * 60 * 24

--- a/src/main/java/com/beour/user/enums/TokenExpireTime.java
+++ b/src/main/java/com/beour/user/enums/TokenExpireTime.java
@@ -7,9 +7,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum TokenExpireTime {
 
-    //10분
-    ACCESS_TOKEN_EXPIRATION_MILLIS(1000L * 60 * 10, "access token 만료 시간"),
-    //1일
+    //10분  1000L * 60 * 10
+    ACCESS_TOKEN_EXPIRATION_MILLIS(1000L * 60, "access token 만료 시간"),
+    //1일  1000L * 60 * 60 * 24
     REFRESH_TOKEN_EXPIRATION_MILLIS(1000L * 60 * 60 * 24, "refresh token 만료 시간");
 
     private final long value;

--- a/src/main/java/com/beour/user/enums/TokenExpireTime.java
+++ b/src/main/java/com/beour/user/enums/TokenExpireTime.java
@@ -7,9 +7,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum TokenExpireTime {
 
-    //todo : token 만료 시간
     //10분  1000L * 60 * 10
-    ACCESS_TOKEN_EXPIRATION_MILLIS(1000L * 60, "access token 만료 시간"),
+    ACCESS_TOKEN_EXPIRATION_MILLIS(1000L * 60 * 10, "access token 만료 시간"),
     //1일  1000L * 60 * 60 * 24
     REFRESH_TOKEN_EXPIRATION_MILLIS(1000L * 60 * 60 * 24, "refresh token 만료 시간");
 

--- a/src/test/java/com/beour/user/controller/LoginControllerTest.java
+++ b/src/test/java/com/beour/user/controller/LoginControllerTest.java
@@ -328,7 +328,8 @@ class LoginControllerTest {
         //when  then
         mockMvc.perform(post("/api/token/reissue"))
             .andExpect(status().isNotFound())
-            .andExpect(jsonPath("$.message").value(UserErrorCode.REFRESH_TOKEN_NOT_FOUND.getMessage()));
+            .andExpect(
+                jsonPath("$.message").value(UserErrorCode.REFRESH_TOKEN_NOT_FOUND.getMessage()));
     }
 
     @Test
@@ -351,7 +352,8 @@ class LoginControllerTest {
         //when  then
         mockMvc.perform(post("/api/token/reissue").cookie(cookie))
             .andExpect(status().isNotFound())
-            .andExpect(jsonPath("$.message").value(UserErrorCode.REFRESH_TOKEN_NOT_FOUND.getMessage()));
+            .andExpect(
+                jsonPath("$.message").value(UserErrorCode.REFRESH_TOKEN_NOT_FOUND.getMessage()));
     }
 
     @Test
@@ -375,6 +377,7 @@ class LoginControllerTest {
         //when  then
         mockMvc.perform(post("/api/token/reissue").cookie(cookie))
             .andExpect(status().isUnauthorized())
-            .andExpect(jsonPath("$.message").value(UserErrorCode.REFRESH_TOKEN_EXPIRED.getMessage()));
+            .andExpect(
+                jsonPath("$.message").value(UserErrorCode.REFRESH_TOKEN_EXPIRED.getMessage()));
     }
 }

--- a/src/test/java/com/beour/user/controller/LoginControllerTest.java
+++ b/src/test/java/com/beour/user/controller/LoginControllerTest.java
@@ -8,10 +8,16 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.beour.global.exception.error.errorcode.UserErrorCode;
+import com.beour.global.jwt.JWTUtil;
+import com.beour.token.entity.RefreshToken;
 import com.beour.token.repository.RefreshTokenRepository;
 import com.beour.user.entity.User;
+import com.beour.user.enums.TokenExpireTime;
 import com.beour.user.repository.UserRepository;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.constraints.AssertTrue;
+import java.time.LocalDateTime;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -36,6 +42,8 @@ class LoginControllerTest {
     private RefreshTokenRepository refreshTokenRepository;
     @Autowired
     private BCryptPasswordEncoder passwordEncoder;
+    @Autowired
+    private JWTUtil jwtUtil;
 
     @BeforeEach
     void setUp() {
@@ -289,4 +297,84 @@ class LoginControllerTest {
             .andExpect(jsonPath("$.message").value(UserErrorCode.USER_ROLE_MISMATCH.getMessage()));
     }
 
+    @Test
+    @DisplayName("토큰 재발급 - 성공")
+    void success_reissue() throws Exception {
+        //given
+        String loginId = "user1";
+        String role = "GUEST";
+
+        String refreshToken = jwtUtil.createJwt("refresh", loginId, role,
+            TokenExpireTime.REFRESH_TOKEN_EXPIRATION_MILLIS.getValue());
+        refreshTokenRepository.save(RefreshToken.builder()
+            .loginId(loginId)
+            .refresh(refreshToken)
+            .expiration(String.valueOf(LocalDateTime.now().plusDays(1)))
+            .build());
+
+        Cookie cookie = new Cookie("refresh", refreshToken);
+
+        //when  then
+        mockMvc.perform(post("/api/token/reissue").cookie(cookie))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data.accessToken").exists())
+            .andExpect(cookie().exists("refresh"))
+            .andExpect(header().exists("Authorization"));
+    }
+
+    @Test
+    @DisplayName("토큰 재발급 - refresh 토큰 없음")
+    void reissue_refresh_token_not_found() throws Exception {
+        //when  then
+        mockMvc.perform(post("/api/token/reissue"))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.message").value(UserErrorCode.REFRESH_TOKEN_NOT_FOUND.getMessage()));
+    }
+
+    @Test
+    @DisplayName("토큰 재발급 - 카테고리 불일치")
+    void reissue_token_category_mismatch() throws Exception {
+        //given
+        String loginId = "user1";
+        String role = "GUEST";
+
+        String refreshToken = jwtUtil.createJwt("access", loginId, role,
+            TokenExpireTime.REFRESH_TOKEN_EXPIRATION_MILLIS.getValue());
+        refreshTokenRepository.save(RefreshToken.builder()
+            .loginId(loginId)
+            .refresh(refreshToken)
+            .expiration(String.valueOf(LocalDateTime.now().plusDays(1)))
+            .build());
+
+        Cookie cookie = new Cookie("refresh", refreshToken);
+
+        //when  then
+        mockMvc.perform(post("/api/token/reissue").cookie(cookie))
+            .andExpect(status().isNotFound())
+            .andExpect(jsonPath("$.message").value(UserErrorCode.REFRESH_TOKEN_NOT_FOUND.getMessage()));
+    }
+
+    @Test
+    @DisplayName("토큰 재발급 - refresh 토큰 만료")
+    void reissue_token_expired() throws Exception {
+        //given
+        String loginId = "user1";
+        String role = "GUEST";
+
+        String refreshToken = jwtUtil.createJwt("refresh", loginId, role, 1L);
+        Thread.sleep(10);
+
+        refreshTokenRepository.save(RefreshToken.builder()
+            .loginId(loginId)
+            .refresh(refreshToken)
+            .expiration(String.valueOf(LocalDateTime.now().plusDays(1)))
+            .build());
+
+        Cookie cookie = new Cookie("refresh", refreshToken);
+
+        //when  then
+        mockMvc.perform(post("/api/token/reissue").cookie(cookie))
+            .andExpect(status().isUnauthorized())
+            .andExpect(jsonPath("$.message").value(UserErrorCode.REFRESH_TOKEN_EXPIRED.getMessage()));
+    }
 }

--- a/src/test/java/com/beour/user/service/LoginServiceTest.java
+++ b/src/test/java/com/beour/user/service/LoginServiceTest.java
@@ -71,9 +71,10 @@ class LoginServiceTest {
     }
 
     @AfterEach
-    void cleanUp(){
+    void cleanUp() {
         refreshTokenRepository.deleteAll();
     }
+
     @Test
     @DisplayName("로그인아이디찾기-일치하는 회원 없음")
     void findLoginId_user_not_found() {
@@ -197,9 +198,9 @@ class LoginServiceTest {
         //given
         MockHttpServletRequest request = new MockHttpServletRequest();
 
-
         // when  then
-        TokenNotFoundException exception = assertThrows(TokenNotFoundException.class, () -> loginService.reissueRefreshToken(request));
+        TokenNotFoundException exception = assertThrows(TokenNotFoundException.class,
+            () -> loginService.reissueRefreshToken(request));
         assertEquals(UserErrorCode.REFRESH_TOKEN_NOT_FOUND.getMessage(), exception.getMessage());
     }
 
@@ -222,7 +223,8 @@ class LoginServiceTest {
         request.setCookies(new Cookie("refresh", refreshToken));
 
         // when  then
-        TokenNotFoundException exception = assertThrows(TokenNotFoundException.class, () -> loginService.reissueRefreshToken(request));
+        TokenNotFoundException exception = assertThrows(TokenNotFoundException.class,
+            () -> loginService.reissueRefreshToken(request));
         assertEquals(UserErrorCode.REFRESH_TOKEN_NOT_FOUND.getMessage(), exception.getMessage());
     }
 
@@ -247,7 +249,8 @@ class LoginServiceTest {
         Thread.sleep(10);
 
         // when  then
-        TokenExpiredException exception = assertThrows(TokenExpiredException.class, () -> loginService.reissueRefreshToken(request));
+        TokenExpiredException exception = assertThrows(TokenExpiredException.class,
+            () -> loginService.reissueRefreshToken(request));
         assertEquals(UserErrorCode.REFRESH_TOKEN_EXPIRED.getMessage(), exception.getMessage());
     }
 

--- a/src/test/java/com/beour/user/service/LoginServiceTest.java
+++ b/src/test/java/com/beour/user/service/LoginServiceTest.java
@@ -3,18 +3,28 @@ package com.beour.user.service;
 import static org.junit.jupiter.api.Assertions.*;
 
 import com.beour.global.exception.error.errorcode.UserErrorCode;
+import com.beour.global.exception.exceptionType.TokenExpiredException;
+import com.beour.global.exception.exceptionType.TokenNotFoundException;
 import com.beour.global.exception.exceptionType.UserNotFoundException;
+import com.beour.global.jwt.JWTUtil;
+import com.beour.token.entity.RefreshToken;
+import com.beour.token.repository.RefreshTokenRepository;
 import com.beour.user.dto.FindLoginIdRequestDto;
 import com.beour.user.dto.FindLoginIdResponseDto;
 import com.beour.user.dto.ResetPasswordRequestDto;
 import com.beour.user.dto.ResetPasswordResponseDto;
 import com.beour.user.entity.User;
+import com.beour.user.enums.TokenExpireTime;
 import com.beour.user.repository.UserRepository;
+import jakarta.servlet.http.Cookie;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.ActiveProfiles;
 
@@ -28,6 +38,10 @@ class LoginServiceTest {
     private LoginService loginService;
     @Autowired
     private PasswordEncoder passwordEncoder;
+    @Autowired
+    private JWTUtil jwtUtil;
+    @Autowired
+    private RefreshTokenRepository refreshTokenRepository;
 
     @BeforeEach
     void setUp() {
@@ -56,6 +70,10 @@ class LoginServiceTest {
         userRepository.save(deleteUser);
     }
 
+    @AfterEach
+    void cleanUp(){
+        refreshTokenRepository.deleteAll();
+    }
     @Test
     @DisplayName("로그인아이디찾기-일치하는 회원 없음")
     void findLoginId_user_not_found() {
@@ -141,6 +159,96 @@ class LoginServiceTest {
         User after = userRepository.findByLoginId(requestDto.getLoginId()).orElse(null);
         assertNotEquals(before.getPassword(), after.getPassword());
         assertTrue(passwordEncoder.matches(result.getTempPassword(), after.getPassword()));
+    }
+
+    @Test
+    @DisplayName("토큰 재발급 - 성공")
+    void success_reissueRefreshToken() {
+        // given
+        String loginId = "user1";
+        String role = "GUEST";
+        String refreshToken = jwtUtil.createJwt("refresh", loginId, role,
+            TokenExpireTime.REFRESH_TOKEN_EXPIRATION_MILLIS.getValue());
+
+        refreshTokenRepository.save(RefreshToken.builder()
+            .loginId(loginId)
+            .refresh(refreshToken)
+            .expiration(String.valueOf(LocalDateTime.now().plusDays(1)))
+            .build());
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setCookies(new Cookie("refresh", refreshToken));
+
+        // when
+        String[] result = loginService.reissueRefreshToken(request);
+
+        // then
+        assertNotNull(result[0]);
+        assertTrue(result[0].startsWith("Bearer "));
+        assertNotNull(result[1]);
+        assertNotSame(refreshToken, result[1]);
+        assertTrue(refreshTokenRepository.existsByRefresh(result[1]));
+        assertEquals(1, refreshTokenRepository.count());
+    }
+
+    @Test
+    @DisplayName("토큰 재발급 - refresh token 없을 경우")
+    void reissueRefreshToken_refresh_token_not_found() {
+        //given
+        MockHttpServletRequest request = new MockHttpServletRequest();
+
+
+        // when  then
+        TokenNotFoundException exception = assertThrows(TokenNotFoundException.class, () -> loginService.reissueRefreshToken(request));
+        assertEquals(UserErrorCode.REFRESH_TOKEN_NOT_FOUND.getMessage(), exception.getMessage());
+    }
+
+    @Test
+    @DisplayName("토큰 재발급 - refresh token이 아닐 경우")
+    void reissueRefreshToken_not_refresh_token() {
+        // given
+        String loginId = "user1";
+        String role = "GUEST";
+        String refreshToken = jwtUtil.createJwt("access", loginId, role,
+            TokenExpireTime.REFRESH_TOKEN_EXPIRATION_MILLIS.getValue());
+
+        refreshTokenRepository.save(RefreshToken.builder()
+            .loginId(loginId)
+            .refresh(refreshToken)
+            .expiration(String.valueOf(LocalDateTime.now().plusDays(1)))
+            .build());
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setCookies(new Cookie("refresh", refreshToken));
+
+        // when  then
+        TokenNotFoundException exception = assertThrows(TokenNotFoundException.class, () -> loginService.reissueRefreshToken(request));
+        assertEquals(UserErrorCode.REFRESH_TOKEN_NOT_FOUND.getMessage(), exception.getMessage());
+    }
+
+    @Test
+    @DisplayName("토큰 재발급 - refresh token 만료")
+    void reissueRefreshToken_refresh_token_expired() throws Exception {
+        // given
+        String loginId = "user1";
+        String role = "GUEST";
+        String refreshToken = jwtUtil.createJwt("refresh", loginId, role,
+            1L);
+
+        refreshTokenRepository.save(RefreshToken.builder()
+            .loginId(loginId)
+            .refresh(refreshToken)
+            .expiration(String.valueOf(LocalDateTime.now().plusDays(1)))
+            .build());
+
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setCookies(new Cookie("refresh", refreshToken));
+
+        Thread.sleep(10);
+
+        // when  then
+        TokenExpiredException exception = assertThrows(TokenExpiredException.class, () -> loginService.reissueRefreshToken(request));
+        assertEquals(UserErrorCode.REFRESH_TOKEN_EXPIRED.getMessage(), exception.getMessage());
     }
 
 }


### PR DESCRIPTION
## ISSUE
[#145] 로그인 기능 및 토큰 관련 로직 리팩터링 및 테스트 코드 작성

## 변경 및 추가 사항
- JWTFilter 리팩토링
  - access token 파싱 로직 extractAccessToken 메서드로 분리
  - 에러 응답 로직 writeErrorResponse 메서드로 통합
- 로그아웃 url /api/logout으로 변경
- accesstoken 재발행 service, controller 테스트 코드 추가 