### PR TITLE
[#148] bug & fix: 아이디 중복 체크에 admin 중복 확인 추가

### DIFF
--- a/src/main/java/com/beour/user/service/SignupService.java
+++ b/src/main/java/com/beour/user/service/SignupService.java
@@ -37,6 +37,8 @@ public class SignupService {
     }
 
     public boolean checkLoginIdDuplicate(String loginId) {
+        checkDuplicateWithAdminId(loginId);
+
         Boolean isUserExist = userRepository.existsByLoginIdAndDeletedAtIsNull(loginId);
 
         if (isUserExist) {


### PR DESCRIPTION
## ISSUE
[#148] 버그 찾기 챌린지

## 🔍 찾아낸 버그
✅ 회원가입 요청 (POST /api/signup)
SignupService.create() 내부에서 checkValidUser() 실행
이 checkValidUser()는 다음을 검증:
- checkDuplicateWithAdminId() → "admin" 금지
- checkLoginIdDuplicate() → DB 중복 여부 확인
- checkNicknameDuplicate() → DB 중복 여부 확인

✅ 즉, "admin"이라는 아이디는 사용할 수 없음.

❌ 중복 체크 요청 (GET /api/signup/check-duplicate/loginId)
SignupController에서 바로 signupService.checkLoginIdDuplicate()만 호출함. 즉, checkDuplicateWithAdminId(): "admin" 금지는 호출하지 않음.

✅ 즉, "admin"은 중복 체크 시에는 "사용 가능"하다고 나오지만, 실제 가입 시에는 실패하는 버그가 발생할 수 있습니다!

## ✅ 수정한 코드
checkLoginIdDuplicate()에 checkDuplicateWithAdminId() 호출하도록 코드 한 줄 추가

## 제 코드가 아니라서 잘못 이해했을 수 있으니, 천천히 읽어보고 검토해주세욥!!