### PR TITLE
[#148] refactor: 아이디 체크 로직 중복 제거 및 cookie 세팅 수정

### DIFF
--- a/src/main/java/com/beour/global/jwt/ManageCookie.java
+++ b/src/main/java/com/beour/global/jwt/ManageCookie.java
@@ -7,7 +7,7 @@ public class ManageCookie {
     public static Cookie createCookie(String key, String value) {
         Cookie cookie = new Cookie(key, value);
         cookie.setMaxAge(24 * 60 * 60); //refresh와 값 같게
-        cookie.setSecure(true);
+//        cookie.setSecure(true);
         cookie.setPath("/");
         cookie.setHttpOnly(true);
 

--- a/src/main/java/com/beour/user/service/SignupService.java
+++ b/src/main/java/com/beour/user/service/SignupService.java
@@ -25,7 +25,6 @@ public class SignupService {
     }
 
     private void checkValidUser(SignupRequestDto dto) {
-        checkDuplicateWithAdminId(dto.getLoginId());
         checkLoginIdDuplicate(dto.getLoginId());
         checkNicknameDuplicate(dto.getNickname());
     }


### PR DESCRIPTION
## 1. Cookie 관리 세팅
cookie.setSecure(true) => https만 허용하는 함수
현재 배포, 로컬 둘 다 http를 사용하기 때문에 주석처리

## 2. 로그인 중복 체크 로직
checkLoginIdDuplicate() 함수에서 관리자 아이디 체크까지 하므로
checkValidUser()에서 관리자 아이디 체크하는 로직 제거