### PR TITLE
[BE] SPACE - website_url 컬럼 삭제 및 관련 코드 수정한다.

### DIFF
--- a/src/main/java/com/beour/space/domain/entity/Description.java
+++ b/src/main/java/com/beour/space/domain/entity/Description.java
@@ -27,18 +27,16 @@ public class Description {
     private String notice;
     private String locationDescription;
     private String refundPolicy;
-    private String websiteUrl;
 
     // 전체 수정(PUT)
     public void update(String description, String priceGuide, String facilityNotice,
-                       String notice, String locationDescription, String refundPolicy, String websiteUrl) {
+                       String notice, String locationDescription, String refundPolicy) {
         this.description = description;
         this.priceGuide = priceGuide;
         this.facilityNotice = facilityNotice;
         this.notice = notice;
         this.locationDescription = locationDescription;
         this.refundPolicy = refundPolicy;
-        this.websiteUrl = websiteUrl;
     }
 
     // 부분 수정(PATCH)
@@ -65,9 +63,4 @@ public class Description {
     public void updateRefundPolicy(String refundPolicy) {
         this.refundPolicy = refundPolicy;
     }
-
-    public void updateWebsiteUrl(String websiteUrl) {
-        this.websiteUrl = websiteUrl;
-    }
-
 }

--- a/src/main/java/com/beour/space/host/dto/SpaceDetailResponseDto.java
+++ b/src/main/java/com/beour/space/host/dto/SpaceDetailResponseDto.java
@@ -30,7 +30,6 @@ public class SpaceDetailResponseDto {
     private String notice;
     private String locationDescription;
     private String refundPolicy;
-    private String websiteUrl;
 
     private List<String> tags;
     private List<AvailableTimeDto> availableTimes;

--- a/src/main/java/com/beour/space/host/dto/SpaceRegisterRequestDto.java
+++ b/src/main/java/com/beour/space/host/dto/SpaceRegisterRequestDto.java
@@ -49,8 +49,6 @@ public class SpaceRegisterRequestDto {
     @NotBlank(message = "환불 정책은 필수입니다.")
     private String refundPolicy;
 
-    private String websiteUrl;
-
     // 3. Tags
     private List<String> tags;
 

--- a/src/main/java/com/beour/space/host/dto/SpaceUpdateRequestDto.java
+++ b/src/main/java/com/beour/space/host/dto/SpaceUpdateRequestDto.java
@@ -50,8 +50,6 @@ public class SpaceUpdateRequestDto {
     @NotBlank(message = "환불 정책은 필수입니다.")
     private String refundPolicy;
 
-    private String websiteUrl;
-
     // tags, imageUrls
     private List<String> tags;
     private List<String> imageUrls;

--- a/src/main/java/com/beour/space/host/service/SpaceService.java
+++ b/src/main/java/com/beour/space/host/service/SpaceService.java
@@ -62,7 +62,6 @@ public class SpaceService {
                 .notice(dto.getNotice())
                 .locationDescription(dto.getLocationDescription())
                 .refundPolicy(dto.getRefundPolicy())
-                .websiteUrl(dto.getWebsiteUrl())
                 .build();
         descriptionRepository.save(description);
 
@@ -126,7 +125,6 @@ public class SpaceService {
                 .notice(desc.getNotice())
                 .locationDescription(desc.getLocationDescription())
                 .refundPolicy(desc.getRefundPolicy())
-                .websiteUrl(desc.getWebsiteUrl())
                 .tags(space.getTags().stream().map(Tag::getContents).toList())
                 .imageUrls(space.getSpaceImages().stream().map(SpaceImage::getImageUrl).toList())
                 .build();
@@ -170,7 +168,7 @@ public class SpaceService {
         Description desc = space.getDescription();
         desc.update(
                 dto.getDescription(), dto.getPriceGuide(), dto.getFacilityNotice(), dto.getNotice(),
-                dto.getLocationDescription(), dto.getRefundPolicy(), dto.getWebsiteUrl()
+                dto.getLocationDescription(), dto.getRefundPolicy()
         );
 
         // 3. Tags 재저장
@@ -225,7 +223,6 @@ public class SpaceService {
             if (dto.getNotice() != null) desc.updateNotice(dto.getNotice());
             if (dto.getLocationDescription() != null) desc.updateLocationDescription(dto.getLocationDescription());
             if (dto.getRefundPolicy() != null) desc.updateRefundPolicy(dto.getRefundPolicy());
-            if (dto.getWebsiteUrl() != null) desc.updateWebsiteUrl(dto.getWebsiteUrl());
         }
     }
 


### PR DESCRIPTION
## ISSUE
[#153] SPACE - website_url 컬럼 삭제 및 관련 코드 수정

## 수정 사항
Description entity에서 websiteUrl을 삭제하고 관련된 모든 코드를 수정.
Description Entity, SpaceDetailResponseDto, SpaceRegisterRequestDto, SpaceUpdateRequestDto, SpaceService 수정.

## (기타) 데이터베이스 마이그레이션 필요

코드 수정과 함께 데이터베이스에서도 `description` 테이블의 `website_url` 컬럼을 삭제하는 마이그레이션 스크립트가 필요함:

```sql
ALTER TABLE description DROP COLUMN website_url;
```