### PR TITLE
[BE] KakaoMapService 리펙토링 - 하드코딩된 예외 메시지 제거 및 개선

### DIFF
--- a/src/main/java/com/beour/global/exception/KakaoMapExceptionHandler.java
+++ b/src/main/java/com/beour/global/exception/KakaoMapExceptionHandler.java
@@ -1,0 +1,44 @@
+package com.beour.global.exception;
+
+import com.beour.global.exception.exceptionType.KakaoMapException;
+import com.beour.global.response.ErrorResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class KakaoMapExceptionHandler {
+
+    @ExceptionHandler(KakaoMapException.class)
+    public ResponseEntity<ErrorResponse> handleKakaoMapException(KakaoMapException ex) {
+        log.error("KakaoMap API 오류 발생: {}", ex.getMessage(), ex);
+
+        HttpStatus status = determineHttpStatus(ex.getErrorCode());
+
+        return ResponseEntity.status(status)
+                .body(new ErrorResponse(ex.getErrorCode(), determineErrorType(ex.getErrorCode()), ex.getMessage()));
+    }
+
+    private HttpStatus determineHttpStatus(Integer errorCode) {
+        if (errorCode == 404) {
+            return HttpStatus.NOT_FOUND;
+        } else if (errorCode == 400) {
+            return HttpStatus.BAD_REQUEST;
+        } else {
+            return HttpStatus.INTERNAL_SERVER_ERROR;
+        }
+    }
+
+    private String determineErrorType(Integer errorCode) {
+        if (errorCode == 404) {
+            return "ADDRESS_NOT_FOUND";
+        } else if (errorCode == 400) {
+            return "INVALID_ADDRESS";
+        } else {
+            return "KAKAO_API_ERROR";
+        }
+    }
+}

--- a/src/main/java/com/beour/global/exception/error/errorcode/KakaoMapErrorCode.java
+++ b/src/main/java/com/beour/global/exception/error/errorcode/KakaoMapErrorCode.java
@@ -1,0 +1,17 @@
+package com.beour.global.exception.error.errorcode;
+
+import com.beour.global.exception.error.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum KakaoMapErrorCode implements ErrorCode {
+
+    API_CALL_FAILED(500, "카카오맵 API 호출에 실패했습니다."),
+    ADDRESS_NOT_FOUND(404, "주소로 좌표를 찾을 수 없습니다."),
+    INVALID_ADDRESS_FORMAT(400, "올바르지 않은 주소 형식입니다.");
+
+    private final Integer code;
+    private final String message;
+}

--- a/src/main/java/com/beour/global/exception/exceptionType/KakaoMapException.java
+++ b/src/main/java/com/beour/global/exception/exceptionType/KakaoMapException.java
@@ -1,0 +1,17 @@
+package com.beour.global.exception.exceptionType;
+
+import com.beour.global.exception.error.ErrorCode;
+
+public class KakaoMapException extends RuntimeException {
+
+    private final Integer errorCode;
+
+    public KakaoMapException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode.getCode();
+    }
+
+    public Integer getErrorCode() {
+        return errorCode;
+    }
+}

--- a/src/main/java/com/beour/space/host/service/KakaoMapService.java
+++ b/src/main/java/com/beour/space/host/service/KakaoMapService.java
@@ -1,11 +1,14 @@
 package com.beour.space.host.service;
 
+import com.beour.global.exception.error.errorcode.KakaoMapErrorCode;
+import com.beour.global.exception.exceptionType.KakaoMapException;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.http.*;
 import org.json.JSONArray;
@@ -22,40 +25,74 @@ public class KakaoMapService {
     private String kakaoApiKey;
 
     public double[] getLatitudeAndLongitude(String address) {
+        validateAddress(address);
         Coordinate coordinate = getCoordinatesByAddress(address);
         return new double[]{coordinate.getLatitude(), coordinate.getLongitude()};
     }
 
     public Coordinate getCoordinatesByAddress(String address) {
+        validateAddress(address);
+
         String url = "https://dapi.kakao.com/v2/local/search/address.json?query=" + address;
 
         HttpHeaders headers = new HttpHeaders();
         headers.set("Authorization", "KakaoAK " + kakaoApiKey);
         HttpEntity<String> entity = new HttpEntity<>(headers);
 
-        ResponseEntity<String> response = restTemplate.exchange(
-                url,
-                HttpMethod.GET,
-                entity,
-                String.class
-        );
+        try {
+            ResponseEntity<String> response = restTemplate.exchange(
+                    url,
+                    HttpMethod.GET,
+                    entity,
+                    String.class
+            );
 
-        if (response.getStatusCode() != HttpStatus.OK) {
-            throw new RuntimeException("카카오맵 API 호출 실패: " + response.getStatusCode());
+            if (response.getStatusCode() != HttpStatus.OK) {
+                log.error("카카오맵 API 호출 실패: 상태코드 {}, 주소: {}", response.getStatusCode(), address);
+                throw new KakaoMapException(KakaoMapErrorCode.API_CALL_FAILED);
+            }
+
+            return parseCoordinatesFromResponse(response.getBody(), address);
+
+        } catch (Exception e) {
+            if (e instanceof KakaoMapException) {
+                throw e;
+            }
+            log.error("카카오맵 API 호출 중 예외 발생: 주소 {}", address, e);
+            throw new KakaoMapException(KakaoMapErrorCode.API_CALL_FAILED);
         }
+    }
 
-        JSONObject json = new JSONObject(response.getBody());
-        JSONArray documents = json.getJSONArray("documents");
-
-        if (documents.isEmpty()) {
-            throw new RuntimeException("주소로 좌표를 찾을 수 없습니다: " + address);
+    private void validateAddress(String address) {
+        if (!StringUtils.hasText(address)) {
+            throw new KakaoMapException(KakaoMapErrorCode.INVALID_ADDRESS_FORMAT);
         }
+    }
 
-        JSONObject location = documents.getJSONObject(0);
-        double latitude = location.getDouble("y");
-        double longitude = location.getDouble("x");
+    private Coordinate parseCoordinatesFromResponse(String responseBody, String address) {
+        try {
+            JSONObject json = new JSONObject(responseBody);
+            JSONArray documents = json.getJSONArray("documents");
 
-        return new Coordinate(latitude, longitude);
+            if (documents.isEmpty()) {
+                log.warn("주소로 좌표를 찾을 수 없음: {}", address);
+                throw new KakaoMapException(KakaoMapErrorCode.ADDRESS_NOT_FOUND);
+            }
+
+            JSONObject location = documents.getJSONObject(0);
+            double latitude = location.getDouble("y");
+            double longitude = location.getDouble("x");
+
+            log.debug("주소 좌표 변환 성공: {} -> 위도: {}, 경도: {}", address, latitude, longitude);
+            return new Coordinate(latitude, longitude);
+
+        } catch (Exception e) {
+            if (e instanceof KakaoMapException) {
+                throw e;
+            }
+            log.error("카카오맵 API 응답 파싱 실패: 주소 {}", address, e);
+            throw new KakaoMapException(KakaoMapErrorCode.API_CALL_FAILED);
+        }
     }
 
     @Getter


### PR DESCRIPTION
## ISSUE
[#94] [HOST] Space 도메인 리펙토링 & 테스트

## 수정사항

1. **KakaoMapErrorCode.java** - 카카오맵 관련 에러 코드 enum
   - `API_CALL_FAILED`: API 호출 실패 시
   - `ADDRESS_NOT_FOUND`: 주소로 좌표를 찾을 수 없을 때
   - `INVALID_ADDRESS_FORMAT`: 올바르지 않은 주소 형식

2. **KakaoMapException.java** - 카카오맵 전용 예외 클래스
   - 다른 예외 클래스들과 동일한 패턴으로 구현

3. **KakaoMapExceptionHandler.java** - 카카오맵 예외 전용 핸들러
   - 에러 코드에 따른 적절한 HTTP 상태 코드 매핑
   - 로깅 기능 추가

## 4. KakaoMapService 수정사항
1. **하드코딩된 예외 메시지 제거**: enum을 통한 중앙집중식 에러 관리
2. **입력값 검증 추가**: 주소가 비어있거나 null인 경우 사전 검증
3. **예외 처리 강화**: try-catch 블록을 통한 안전한 예외 처리
4. **로깅 개선**: 성공/실패 상황에 대한 상세한 로그 추가
5. **메서드 분리**: `parseCoordinatesFromResponse`, `validateAddress` 등으로 책임 분리
