### PR TITLE
[BE] 회원 탈퇴 로직 리팩토링 및 테스트 코드를 작성한다.

### DIFF
--- a/src/main/java/com/beour/global/exception/UserExceptionHandler.java
+++ b/src/main/java/com/beour/global/exception/UserExceptionHandler.java
@@ -3,6 +3,7 @@ package com.beour.global.exception;
 import com.beour.global.exception.exceptionType.DuplicateUserInfoException;
 import com.beour.global.exception.exceptionType.InvalidCredentialsException;
 import com.beour.global.exception.exceptionType.UserNotFoundException;
+import com.beour.global.exception.exceptionType.UserWithdrawException;
 import com.beour.global.response.ErrorResponse;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
@@ -32,5 +33,11 @@ public class UserExceptionHandler {
     public ResponseEntity<ErrorResponse> handleDuplicateUserInfo(DuplicateUserInfoException ex) {
         return ResponseEntity.status(HttpStatus.CONFLICT)
             .body(new ErrorResponse(ex.getErrorCode(), "DUPLICATE_USER_INFO", ex.getMessage()));
+    }
+
+    @ExceptionHandler(UserWithdrawException.class)
+    public ResponseEntity<ErrorResponse> handleUserWithdraw(UserWithdrawException ex) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+            .body(new ErrorResponse(ex.getErrorCode(), "USER_WITHDRAW_IMPOSSIBLE", ex.getMessage()));
     }
 }

--- a/src/main/java/com/beour/global/exception/error/errorcode/ReservationErrorCode.java
+++ b/src/main/java/com/beour/global/exception/error/errorcode/ReservationErrorCode.java
@@ -13,6 +13,7 @@ public enum ReservationErrorCode implements ErrorCode {
     INVALID_PRICE(400, "해당 가격이 맞지 않습니다."),
     CANNOT_CANCEL_RESERVATION(400, "해당 예약은 취소할 수 없습니다."),
     SPACE_MISMATCH(400, "예약과 공간 정보가 일치하지 않습니다."),
+    FUTURE_RESERVATION_REMAIN(400, "해당 유저의 완료되지 않은 예약이 존재합니다."),
     RESERVATION_NOT_FOUND(404, "예약이 존재하지 않습니다.");
 
     private final Integer code;

--- a/src/main/java/com/beour/global/exception/error/errorcode/UserErrorCode.java
+++ b/src/main/java/com/beour/global/exception/error/errorcode/UserErrorCode.java
@@ -13,6 +13,7 @@ public enum UserErrorCode implements ErrorCode {
     LOGIN_ID_DUPLICATE(409, "이미 사용중인 아이디입니다."),
     NICKNAME_DUPLICATE(409, "이미 사용중인 닉네임입니다."),
     USER_ROLE_MISMATCH(400, "역할이 일치하지 않습니다."),
+    USER_WITHDRAW_IMPOSSIBLE(400, "해당 유저는 탈퇴할 수 없습니다."),
     ACCESS_TOKEN_EXPIRED(401, "access 토큰이 만료되었습니다."),
     NOT_ACCESS_TOKEN(401, "access 토큰이 아닙니다."),
     ACCESS_TOKEN_NOT_FOUND(404, "access 토큰이 존재하지 않습니다."),

--- a/src/main/java/com/beour/global/exception/exceptionType/UserWithdrawException.java
+++ b/src/main/java/com/beour/global/exception/exceptionType/UserWithdrawException.java
@@ -1,0 +1,16 @@
+package com.beour.global.exception.exceptionType;
+
+import com.beour.global.exception.error.ErrorCode;
+
+public class UserWithdrawException extends RuntimeException{
+    private final Integer errorCode;
+
+    public UserWithdrawException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode.getCode();
+    }
+
+    public Integer getErrorCode(){
+        return this.errorCode;
+    }
+}

--- a/src/main/java/com/beour/reservation/commons/repository/ReservationRepository.java
+++ b/src/main/java/com/beour/reservation/commons/repository/ReservationRepository.java
@@ -12,31 +12,44 @@ import org.springframework.data.repository.query.Param;
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
 
     List<Reservation> findBySpaceIdAndDateAndDeletedAtIsNull(Long spaceId, LocalDate date);
-    List<Reservation> findBySpaceIdAndDateAndStatusNot(Long spaceId, LocalDate date, ReservationStatus status);
+
+    List<Reservation> findBySpaceIdAndDateAndStatusNot(Long spaceId, LocalDate date,
+        ReservationStatus status);
 
     @Query("SELECT r FROM Reservation r JOIN FETCH r.space " +
-            "WHERE r.guest.id = :guestId AND " +
-            "(r.date > :today OR (r.date = :today AND r.startTime > :now))")
+        "WHERE r.guest.id = :guestId AND " +
+        "(r.date > :today OR (r.date = :today AND r.startTime > :now))")
     List<Reservation> findUpcomingReservationsByGuest(
-            @Param("guestId") Long guestId,
-            @Param("today") LocalDate today,
-            @Param("now") LocalTime now
+        @Param("guestId") Long guestId,
+        @Param("today") LocalDate today,
+        @Param("now") LocalTime now
     );
 
     @Query("SELECT r FROM Reservation r " +
-            "WHERE r.guest.id = :guestId AND " +
-            "(r.date < :today OR (r.date = :today AND r.endTime <= :now))")
+        "WHERE r.guest.id = :guestId AND " +
+        "(r.date < :today OR (r.date = :today AND r.endTime <= :now))")
     List<Reservation> findPastReservationsByGuest(
-            @Param("guestId") Long guestId,
-            @Param("today") LocalDate today,
-            @Param("now") LocalTime now
+        @Param("guestId") Long guestId,
+        @Param("today") LocalDate today,
+        @Param("now") LocalTime now
     );
 
     @Query("SELECT r FROM Reservation r JOIN FETCH r.space WHERE r.guest.id = :guestId AND r.status = 'COMPLETED' AND r.deletedAt IS NULL")
     List<Reservation> findCompletedReservationsWithSpaceByGuestId(@Param("guestId") Long guestId);
 
     List<Reservation> findByHostIdAndDateAndDeletedAtIsNull(Long hostId, LocalDate date);
-    List<Reservation> findByHostIdAndDateAndSpaceIdAndDeletedAtIsNull(Long hostId, LocalDate date, Long spaceId);
-    List<Reservation> findByHostIdAndDateAndStatusAndDeletedAtIsNull(Long hostId, LocalDate date, ReservationStatus status);
-    List<Reservation> findByHostIdAndDateAndSpaceIdAndStatusAndDeletedAtIsNull(Long hostId, LocalDate date, Long spaceId, ReservationStatus status);
+
+    List<Reservation> findByHostIdAndDateAndSpaceIdAndDeletedAtIsNull(Long hostId, LocalDate date,
+        Long spaceId);
+
+    List<Reservation> findByHostIdAndDateAndStatusAndDeletedAtIsNull(Long hostId, LocalDate date,
+        ReservationStatus status);
+
+    List<Reservation> findByHostIdAndDateAndSpaceIdAndStatusAndDeletedAtIsNull(Long hostId,
+        LocalDate date, Long spaceId, ReservationStatus status);
+
+    List<Reservation> findByHostIdAndStatusInAndDeletedAtIsNull(Long hostId,
+        List<ReservationStatus> statuses);
+    List<Reservation> findByGuestIdAndStatusInAndDeletedAtIsNull(Long guestId,
+        List<ReservationStatus> statuses);
 }

--- a/src/test/java/com/beour/user/controller/MyInformationUserDeleteControllerTest.java
+++ b/src/test/java/com/beour/user/controller/MyInformationUserDeleteControllerTest.java
@@ -1,0 +1,206 @@
+package com.beour.user.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.junit.jupiter.api.Assertions.*;
+
+import com.beour.global.exception.error.errorcode.ReservationErrorCode;
+import com.beour.global.jwt.JWTUtil;
+import com.beour.reservation.commons.entity.Reservation;
+import com.beour.reservation.commons.enums.ReservationStatus;
+import com.beour.reservation.commons.enums.UsagePurpose;
+import com.beour.reservation.commons.repository.ReservationRepository;
+import com.beour.space.domain.entity.Space;
+import com.beour.space.domain.enums.SpaceCategory;
+import com.beour.space.domain.enums.UseCategory;
+import com.beour.space.domain.repository.SpaceRepository;
+import com.beour.user.entity.User;
+import com.beour.user.repository.UserRepository;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@AutoConfigureMockMvc
+public class MyInformationUserDeleteControllerTest {
+
+
+    @Autowired
+    private UserRepository userRepository;
+    @Autowired
+    private SpaceRepository spaceRepository;
+    @Autowired
+    private ReservationRepository reservationRepository;
+    @Autowired
+    private JWTUtil jwtUtil;
+    @Autowired
+    private MockMvc mockMvc;
+
+    private User guest;
+    private String guestToken;
+    private User host;
+    private String hostToken;
+    private Space space;
+
+    @BeforeEach
+    void setUp() {
+        guest = User.builder()
+            .loginId("guest")
+            .password("guestpw")
+            .name("게스트")
+            .nickname("guest")
+            .email("guest@gmail.com")
+            .phone("01012345678")
+            .role("GUEST")
+            .build();
+        userRepository.save(guest);
+
+        guestToken = jwtUtil.createJwt(
+            "access",
+            guest.getLoginId(),
+            "ROLE_" + guest.getRole(),
+            1000L * 60 * 30    // 30분
+        );
+
+        host = User.builder()
+            .loginId("host")
+            .password("hostpw")
+            .name("게스트")
+            .nickname("host")
+            .email("host@gmail.com")
+            .phone("01012345678")
+            .role("HOST")
+            .build();
+        userRepository.save(host);
+
+        hostToken = jwtUtil.createJwt(
+            "access",
+            host.getLoginId(),
+            "ROLE_" + host.getRole(),
+            1000L * 60 * 30    // 30분
+        );
+
+        space = Space.builder()
+            .host(host)
+            .name("공간1")
+            .spaceCategory(SpaceCategory.COOKING)
+            .useCategory(UseCategory.COOKING)
+            .maxCapacity(3)
+            .address("서울시 강남구")
+            .detailAddress("투썸건물 2층")
+            .pricePerHour(15000)
+            .thumbnailUrl("https://example.img")
+            .latitude(123.12)
+            .longitude(123.12)
+            .avgRating(0.0)
+            .availableTimes(new ArrayList<>())
+            .build();
+        spaceRepository.save(space);
+    }
+
+    @AfterEach
+    void tearDown() {
+        reservationRepository.deleteAll();
+        spaceRepository.deleteAll();
+        userRepository.deleteAll();
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("회원 탈퇴(게스트) - 성공")
+    void success_userWithdraw_guest() throws Exception{
+        //when  then
+        mockMvc.perform(delete("/api/users")
+                .header("Authorization", "Bearer " + guestToken)
+            )
+            .andExpect(status().isOk());
+
+        assertTrue(guest.isDeleted());
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("회원 탈퇴(게스트) - 실패(예약 남아있음)")
+    void userWithdraw_with_reservation_future_guest() throws Exception{
+        //given
+        Reservation reservation = Reservation.builder()
+            .guest(guest)
+            .host(host)
+            .space(space)
+            .status(ReservationStatus.ACCEPTED)
+            .usagePurpose(UsagePurpose.BARISTA_TRAINING)
+            .requestMessage("테슽뚜")
+            .date(LocalDate.now().plusDays(1))
+            .startTime(LocalTime.of(12, 0, 0))
+            .endTime(LocalTime.of(16, 0, 0))
+            .price(60000)
+            .guestCount(2)
+            .build();
+        reservationRepository.save(reservation);
+
+        //when  then
+        mockMvc.perform(delete("/api/users")
+                .header("Authorization", "Bearer " + guestToken)
+            )
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.message").value(ReservationErrorCode.FUTURE_RESERVATION_REMAIN.getMessage()));
+
+        assertFalse(guest.isDeleted());
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("회원 탈퇴(호스트) - 성공")
+    void success_userWithdraw_host() throws Exception{
+        //when  then
+        mockMvc.perform(delete("/api/users")
+                .header("Authorization", "Bearer " + hostToken)
+            )
+            .andExpect(status().isOk());
+
+        assertTrue(host.isDeleted());
+        assertTrue(space.isDeleted());
+    }
+
+    @Test
+    @Transactional
+    @DisplayName("회원 탈퇴(호스트) - 실패(예약 남아있음)")
+    void userWithdraw_with_reservation_future_host() throws Exception{
+        //given
+        Reservation reservation = Reservation.builder()
+            .guest(guest)
+            .host(host)
+            .space(space)
+            .status(ReservationStatus.ACCEPTED)
+            .usagePurpose(UsagePurpose.BARISTA_TRAINING)
+            .requestMessage("테슽뚜")
+            .date(LocalDate.now().plusDays(1))
+            .startTime(LocalTime.of(12, 0, 0))
+            .endTime(LocalTime.of(16, 0, 0))
+            .price(60000)
+            .guestCount(2)
+            .build();
+        reservationRepository.save(reservation);
+
+        //when  then
+        mockMvc.perform(delete("/api/users")
+                .header("Authorization", "Bearer " + hostToken)
+            )
+            .andExpect(status().isBadRequest())
+            .andExpect(jsonPath("$.message").value(ReservationErrorCode.FUTURE_RESERVATION_REMAIN.getMessage()));
+
+        assertFalse(host.isDeleted());
+    }
+}


### PR DESCRIPTION
## ISSUE
[#61] 사용자 RUD 리팩토링 및 테스트 코드 작성

## 변경사항
- 회원 탈퇴 로직 수정
  - 게스트 및 호스트 회원 탈퇴시 남아있는 예약 확인 후 탈퇴 수락
  - 호스트 경우 탈퇴 시 호스트의 공간들 삭제 처리
- 예외 처리 추가  