### PR TITLE
[infra] ImageUploader 테스트 시 파일 저장 경로 누락 문제 해결

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Create test resources directory
         run: mkdir -p src/test/resources
 
+      - name: Create upload directory for tests
+        run: mkdir -p ./src/test/resources/uploads
+
       - name: application-test.yml 파일 만들기
         run: echo "${{ secrets.APPLICATION_TEST_PROPERTIES }}" > ./src/test/resources/application-test.yml
 


### PR DESCRIPTION
## ISSUE
[#163] test: ImageUploader 테스트용 업로드 폴더 생성

## 수정 사항
- 테스트 실행 중 업로드 경로가 존재하지 않아 NoSuchFileException이 발생하는 문제 해결

- CI 환경에서 src/test/resources/uploads 디렉토리를 사전에 생성하도록 GitHub Actions 설정 추가
   - file:
  path: src/test/resources/uploads/
  url: http://localhost:8080/uploads/

- 테스트용 application-test.yml에 파일 저장 경로 명시
   - file:
  path: src/test/resources/uploads/
  url: http://localhost:8080/uploads/
