### PR TITLE
feat: WebConfig 설정 추가로 프론트엔드 CORS 허용

### DIFF
--- a/src/main/java/com/beour/global/config/WebConfig.java
+++ b/src/main/java/com/beour/global/config/WebConfig.java
@@ -2,6 +2,7 @@ package com.beour.global.config;
 
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -15,6 +16,14 @@ public class WebConfig implements WebMvcConfigurer {
     public void addResourceHandlers(ResourceHandlerRegistry registry) {
         registry.addResourceHandler("/uploads/**")
             .addResourceLocations("file:" + filePath);
+    }
+
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins("http://localhost:3000") // 프론트 테스트용
+                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                .allowCredentials(true);
     }
 
 }


### PR DESCRIPTION
## 작업 내용
- `global.config.WebConfig` 클래스에 `WebMvcConfigurer`를 구현
- `addCorsMappings`를 오버라이드하여 localhost:3000 도메인에서의 CORS 요청을 허용하도록 설정

##  변경 사항
- `allowedOrigins("http://localhost:3000")`: 프론트엔드 로컬 환경 테스트를 위한 설정
- `allowedMethods`: GET, POST, PUT, DELETE, OPTIONS 허용
- `allowCredentials(true)`: 인증 정보 포함 허용
