### PR TITLE
fix: CORS 허용 도메인에 HTTPS 도메인(beour.store) 추가

### DIFF
--- a/src/main/java/com/beour/global/security/SecurityConfig.java
+++ b/src/main/java/com/beour/global/security/SecurityConfig.java
@@ -62,7 +62,9 @@ public class SecurityConfig {
 
                     configuration.setAllowedOrigins(
                         List.of("http://localhost:3000",
-                            "http://beour-bucket.s3-website.ap-northeast-2.amazonaws.com")
+                                "http://beour-bucket.s3-website.ap-northeast-2.amazonaws.com",
+                                "https://beour.store",
+                                "https://www.beour.store")
                     );
                     configuration.setAllowedMethods(
                         List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));


### PR DESCRIPTION
SecurityConfig의 CORS 설정에 `https://beour.store`, `https://www.beour.store` 도메인을 추가하였습니다.
