### PR TITLE
[BE] GUEST - Review 리펙토링: 이미지 등록/페이징 기능 추가, API url 수정, 테스트 코드 수정

### DIFF
--- a/src/main/java/com/beour/reservation/commons/repository/ReservationRepository.java
+++ b/src/main/java/com/beour/reservation/commons/repository/ReservationRepository.java
@@ -38,6 +38,15 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
         Pageable pageable
     );
 
+    @Query("""
+    SELECT r FROM Reservation r
+    JOIN FETCH r.space
+    WHERE r.guest.id = :guestId 
+    AND r.status = 'COMPLETED'
+    AND r.deletedAt IS NULL
+    """)
+    Page<Reservation> findCompletedReservationsByGuestId(@Param("guestId") Long guestId, Pageable pageable);
+
     @Query("SELECT r FROM Reservation r JOIN FETCH r.space WHERE r.guest.id = :guestId AND r.status = 'COMPLETED' AND r.deletedAt IS NULL")
     List<Reservation> findCompletedReservationsWithSpaceByGuestId(@Param("guestId") Long guestId);
 

--- a/src/main/java/com/beour/review/domain/repository/ReviewRepository.java
+++ b/src/main/java/com/beour/review/domain/repository/ReviewRepository.java
@@ -1,8 +1,9 @@
 package com.beour.review.domain.repository;
 
 import com.beour.review.domain.entity.Review;
-import com.beour.space.domain.entity.Space;
 import java.util.List;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -19,6 +20,14 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     WHERE r.guest.id = :guestId AND r.deletedAt IS NULL
     """)
     List<Review> findAllWithCommentAndImagesByGuestId(@Param("guestId") Long guestId);
+
+    @Query("""
+    SELECT DISTINCT r FROM Review r
+    LEFT JOIN FETCH r.comment
+    LEFT JOIN FETCH r.images
+    WHERE r.guest.id = :guestId AND r.deletedAt IS NULL
+    """)
+    Page<Review> findAllWithCommentAndImagesByGuestIdPaged(@Param("guestId") Long guestId, Pageable pageable);
 
     Optional<Review> findByGuestIdAndSpaceIdAndReservedDateAndDeletedAtIsNull(Long guestId, Long spaceId, LocalDate reservedDate);
 

--- a/src/main/java/com/beour/review/guest/controller/ReviewGuestController.java
+++ b/src/main/java/com/beour/review/guest/controller/ReviewGuestController.java
@@ -6,13 +6,17 @@ import com.beour.review.guest.dto.ReviewDetailResponseDto;
 import com.beour.review.guest.dto.ReviewForReservationResponseDto;
 import com.beour.review.guest.dto.ReviewRequestDto;
 import com.beour.review.guest.dto.ReviewUpdateRequestDto;
-import com.beour.review.guest.dto.ReviewableReservationResponseDto;
-import com.beour.review.guest.dto.WrittenReviewResponseDto;
+import com.beour.review.guest.dto.ReviewableReservationPageResponseDto;
+import com.beour.review.guest.dto.WrittenReviewPageResponseDto;
 import com.beour.review.guest.service.ReviewGuestService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
 import java.util.List;
 
 @RequiredArgsConstructor
@@ -21,42 +25,46 @@ public class ReviewGuestController {
 
     private final ReviewGuestService reviewGuestService;
 
-    @GetMapping("/api/guest/reviews/reviewable")
-    public ApiResponse<List<ReviewableReservationResponseDto>> getReviewableReservations() {
-        return ApiResponse.ok(reviewGuestService.getReviewableReservations());
+    @GetMapping("/api/users/me/reviewable-reservations")
+    public ApiResponse<ReviewableReservationPageResponseDto> getReviewableReservations(
+            @PageableDefault(size = 10, sort = "id") Pageable pageable) {
+        return ApiResponse.ok(reviewGuestService.getReviewableReservations(pageable));
     }
 
-    @GetMapping("/api/guest/reviews/written")
-    public ApiResponse<List<WrittenReviewResponseDto>> getWrittenReviews() {
-        return ApiResponse.ok(reviewGuestService.getWrittenReviews());
+    @GetMapping("/api/users/me/reviews")
+    public ApiResponse<WrittenReviewPageResponseDto> getWrittenReviews(
+            @PageableDefault(size = 10, sort = "createdAt") Pageable pageable) {
+        return ApiResponse.ok(reviewGuestService.getWrittenReviews(pageable));
     }
 
     // 예약 정보 조회 (리뷰 작성을 위한)
-    @GetMapping("/api/guest/reviews/reservation/{reservationId}")
+    @GetMapping("/api/reviews/reservations/{reservationId}")
     public ApiResponse<ReviewForReservationResponseDto> getReservationForReview(@PathVariable(value = "reservationId") Long reservationId) {
         return ApiResponse.ok(reviewGuestService.getReservationForReview(reservationId));
     }
 
-    @PostMapping("/api/guest/reviews")
-    public ApiResponse<String> createReview(@RequestBody @Valid ReviewRequestDto requestDto) {
-        reviewGuestService.createReview(requestDto);
+    @PostMapping("/api/users/me/reviews")
+    public ApiResponse<String> createReview(@RequestPart @Valid ReviewRequestDto requestDto,
+                                            @RequestPart(required = false) List<MultipartFile> images) throws IOException {
+        reviewGuestService.createReview(requestDto, images);
         return ApiResponse.ok("Review가 저장되었습니다.");
     }
 
     // 리뷰 상세 조회
-    @GetMapping("/api/guest/reviews/{reviewId}")
+    @GetMapping("/api/users/me/reviews/{reviewId}")
     public ApiResponse<ReviewDetailResponseDto> getReviewDetail(@PathVariable(value = "reviewId") Long reviewId) {
         return ApiResponse.ok(reviewGuestService.getReviewDetail(reviewId));
     }
 
-    @PatchMapping("/api/guest/reviews/{reviewId}")
+    @PatchMapping("/api/users/me/reviews/{reviewId}")
     public ApiResponse<String> updateReview(@PathVariable(value = "reviewId") Long reviewId,
-                                            @RequestBody @Valid ReviewUpdateRequestDto requestDto) {
-        reviewGuestService.updateReview(reviewId, requestDto);
+                                            @RequestPart @Valid ReviewUpdateRequestDto requestDto,
+                                            @RequestPart(required = false) List<MultipartFile> images) throws IOException {
+        reviewGuestService.updateReview(reviewId, requestDto, images);
         return ApiResponse.ok("Review가 수정되었습니다.");
     }
 
-    @DeleteMapping("/api/guest/reviews/{reviewId}")
+    @DeleteMapping("/api/users/me/reviews/{reviewId}")
     public ApiResponse<String> deleteReview(@PathVariable(value = "reviewId") Long reviewId) {
         reviewGuestService.deleteReview(reviewId);
         return ApiResponse.ok("Review가 삭제되었습니다.");

--- a/src/main/java/com/beour/review/guest/dto/ReviewRequestDto.java
+++ b/src/main/java/com/beour/review/guest/dto/ReviewRequestDto.java
@@ -7,8 +7,6 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.util.List;
-
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
@@ -22,5 +20,6 @@ public class ReviewRequestDto {
 
     @NotNull(message = "리뷰 내용은 필수")
     private String content;
-    private List<String> imageUrls;
+
+    // imageUrls 필드 제거 - 파일 업로드로 대체
 }

--- a/src/main/java/com/beour/review/guest/dto/ReviewUpdateRequestDto.java
+++ b/src/main/java/com/beour/review/guest/dto/ReviewUpdateRequestDto.java
@@ -7,8 +7,6 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.util.List;
-
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
@@ -21,5 +19,5 @@ public class ReviewUpdateRequestDto {
     @NotBlank(message = "리뷰 내용은 비어 있을 수 없습니다.")
     private String content;
 
-    private List<String> imageUrls;
+    // imageUrls 필드 제거 - 파일 업로드로 대체
 }

--- a/src/main/java/com/beour/review/guest/dto/ReviewableReservationPageResponseDto.java
+++ b/src/main/java/com/beour/review/guest/dto/ReviewableReservationPageResponseDto.java
@@ -1,0 +1,14 @@
+package com.beour.review.guest.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class ReviewableReservationPageResponseDto {
+    private List<ReviewableReservationResponseDto> reservations;
+    private boolean last;
+    private int totalPage;
+}

--- a/src/main/java/com/beour/review/guest/dto/WrittenReviewPageResponseDto.java
+++ b/src/main/java/com/beour/review/guest/dto/WrittenReviewPageResponseDto.java
@@ -1,0 +1,14 @@
+package com.beour.review.guest.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class WrittenReviewPageResponseDto {
+    private List<WrittenReviewResponseDto> reviews;
+    private boolean last;
+    private int totalPage;
+}

--- a/src/main/java/com/beour/review/guest/service/ReviewGuestService.java
+++ b/src/main/java/com/beour/review/guest/service/ReviewGuestService.java
@@ -7,6 +7,7 @@ import com.beour.global.exception.exceptionType.DuplicateException;
 import com.beour.global.exception.exceptionType.ReviewNotFoundException;
 import com.beour.global.exception.exceptionType.UnauthorityException;
 import com.beour.global.exception.exceptionType.UserNotFoundException;
+import com.beour.global.file.ImageUploader;
 import com.beour.reservation.commons.entity.Reservation;
 import com.beour.reservation.commons.enums.ReservationStatus;
 import com.beour.reservation.commons.exceptionType.MissMatch;
@@ -21,15 +22,24 @@ import com.beour.review.guest.dto.ReviewDetailResponseDto;
 import com.beour.review.guest.dto.ReviewForReservationResponseDto;
 import com.beour.review.guest.dto.ReviewRequestDto;
 import com.beour.review.guest.dto.ReviewUpdateRequestDto;
+import com.beour.review.guest.dto.ReviewableReservationPageResponseDto;
 import com.beour.review.guest.dto.ReviewableReservationResponseDto;
+import com.beour.review.guest.dto.WrittenReviewPageResponseDto;
 import com.beour.review.guest.dto.WrittenReviewResponseDto;
 import com.beour.user.entity.User;
 import com.beour.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -42,30 +52,46 @@ public class ReviewGuestService {
     private final ReservationRepository reservationRepository;
     private final ReviewRepository reviewRepository;
     private final UserRepository userRepository;
+    private final ImageUploader imageUploader;
 
-    public List<ReviewableReservationResponseDto> getReviewableReservations() {
+    public ReviewableReservationPageResponseDto getReviewableReservations(Pageable pageable) {
         User guest = findUserFromToken();
 
-        List<Reservation> completedReservations = reservationRepository
-            .findCompletedReservationsWithSpaceByGuestId(guest.getId());
+        Page<Reservation> completedReservations = reservationRepository
+                .findCompletedReservationsByGuestId(guest.getId(), pageable);
 
-        return completedReservations.stream()
-            .map(ReviewableReservationResponseDto::of)
-            .toList();
+        checkEmptyReservation(completedReservations);
+
+        List<ReviewableReservationResponseDto> reservations = completedReservations.getContent().stream()
+                .map(ReviewableReservationResponseDto::of)
+                .toList();
+
+        return new ReviewableReservationPageResponseDto(
+                reservations,
+                completedReservations.isLast(),
+                completedReservations.getTotalPages()
+        );
     }
 
-    public List<WrittenReviewResponseDto> getWrittenReviews() {
+    public WrittenReviewPageResponseDto getWrittenReviews(Pageable pageable) {
         User guest = findUserFromToken();
 
-        List<Review> writtenReviews = reviewRepository.findAllWithCommentAndImagesByGuestId(
-            guest.getId());
+        Page<Review> writtenReviews = reviewRepository.findAllWithCommentAndImagesByGuestIdPaged(guest.getId(), pageable);
 
-        return writtenReviews.stream()
-            .map(review -> {
-                ReviewComment comment = review.getComment();
-                return WrittenReviewResponseDto.of(review, comment);
-            })
-            .toList();
+        checkEmptyReviews(writtenReviews);
+
+        List<WrittenReviewResponseDto> reviews = writtenReviews.getContent().stream()
+                .map(review -> {
+                    ReviewComment comment = review.getComment();
+                    return WrittenReviewResponseDto.of(review, comment);
+                })
+                .toList();
+
+        return new WrittenReviewPageResponseDto(
+                reviews,
+                writtenReviews.isLast(),
+                writtenReviews.getTotalPages()
+        );
     }
 
     // 예약 정보 조회 (리뷰 작성을 위한)
@@ -79,7 +105,7 @@ public class ReviewGuestService {
     }
 
     @Transactional
-    public void createReview(ReviewRequestDto requestDto) {
+    public void createReview(ReviewRequestDto requestDto, List<MultipartFile> images) throws IOException {
         User guest = findUserFromToken();
         Reservation reservation = findReservationById(requestDto.getReservationId());
 
@@ -87,11 +113,10 @@ public class ReviewGuestService {
         validateReservationStatus(reservation);
         checkDuplicateReview(guest.getId(), reservation.getSpace().getId(), reservation.getDate());
 
-        Review review = buildReview(guest, reservation, requestDto.getRating(),
-            requestDto.getContent());
+        Review review = buildReview(guest, reservation, requestDto.getRating(), requestDto.getContent());
         Review savedReview = reviewRepository.save(review);
 
-        saveReviewImages(savedReview, requestDto.getImageUrls());
+        saveReviewImages(savedReview, images);
     }
 
     public ReviewDetailResponseDto getReviewDetail(Long reviewId) {
@@ -104,7 +129,7 @@ public class ReviewGuestService {
     }
 
     @Transactional
-    public void updateReview(Long reviewId, ReviewUpdateRequestDto requestDto) {
+    public void updateReview(Long reviewId, ReviewUpdateRequestDto requestDto, List<MultipartFile> images) throws IOException {
         User guest = findUserFromToken();
         Review review = findReviewById(reviewId);
 
@@ -113,7 +138,7 @@ public class ReviewGuestService {
         review.updateRating(requestDto.getRating());
         review.updateContent(requestDto.getContent());
 
-        updateReviewImages(review, requestDto.getImageUrls());
+        updateReviewImages(review, images);
     }
 
     @Transactional
@@ -126,49 +151,48 @@ public class ReviewGuestService {
         review.softDelete();
     }
 
-    public List<RecentWrittenReviewResponseDto> getRecentWrittenReviews() {
+    public List<RecentWrittenReviewResponseDto> getRecentWrittenReviews(){
         List<Review> reviews = reviewRepository.findTop5ByDeletedAtIsNullOrderByCreatedAtDesc();
 
-        if (reviews.isEmpty()) {
+        if(reviews.isEmpty()){
             throw new ReviewNotFoundException(ReviewErrorCode.NO_RECENT_REVIEW);
         }
 
         return reviews.stream()
-            .map(review -> {
-                List<String> imageUrls = Optional.ofNullable(review.getImages())
-                    .orElse(Collections.emptyList())
-                    .stream()
-                    .map(ReviewImage::getImageUrl)
-                    .toList();
+                .map(review -> {
+                    List<String> imageUrls = Optional.ofNullable(review.getImages())
+                            .orElse(Collections.emptyList())
+                            .stream()
+                            .map(ReviewImage::getImageUrl)
+                            .toList();
 
-                return RecentWrittenReviewResponseDto.builder()
-                    .reviewId(review.getId())
-                    .spaceName(review.getSpace().getName())
-                    .reviewerNickName(review.getGuest().getNickname())
-                    .reviewCreatedAt(review.getCreatedAt())
-                    .rating(review.getRating())
-                    .images(imageUrls)
-                    .reviewContent(review.getContent())
-                    .build();
-            }).collect(Collectors.toList());
+                    return RecentWrittenReviewResponseDto.builder()
+                            .spaceName(review.getSpace().getName())
+                            .reviewerNickName(review.getGuest().getNickname())
+                            .reviewCreatedAt(review.getCreatedAt())
+                            .rating(review.getRating())
+                            .images(imageUrls)
+                            .reviewContent(review.getContent())
+                            .build();
+                }).collect(Collectors.toList());
     }
 
     private User findUserFromToken() {
         String loginId = SecurityContextHolder.getContext().getAuthentication().getName();
         return userRepository.findByLoginIdAndDeletedAtIsNull(loginId).orElseThrow(
-            () -> new UserNotFoundException(UserErrorCode.USER_NOT_FOUND)
+                () -> new UserNotFoundException(UserErrorCode.USER_NOT_FOUND)
         );
     }
 
     private Reservation findReservationById(Long reservationId) {
         return reservationRepository.findById(reservationId).orElseThrow(
-            () -> new ReservationNotFound(ReservationErrorCode.RESERVATION_NOT_FOUND)
+                () -> new ReservationNotFound(ReservationErrorCode.RESERVATION_NOT_FOUND)
         );
     }
 
     private Review findReviewById(Long reviewId) {
         return reviewRepository.findById(reviewId).orElseThrow(
-            () -> new ReviewNotFoundException(ReviewErrorCode.REVIEW_NOT_FOUND)
+                () -> new ReviewNotFoundException(ReviewErrorCode.REVIEW_NOT_FOUND)
         );
     }
 
@@ -184,10 +208,9 @@ public class ReviewGuestService {
         }
     }
 
-    private void checkDuplicateReview(Long guestId, Long spaceId,
-        java.time.LocalDate reservedDate) {
+    private void checkDuplicateReview(Long guestId, Long spaceId, java.time.LocalDate reservedDate) {
         if (reviewRepository.findByGuestIdAndSpaceIdAndReservedDateAndDeletedAtIsNull(
-            guestId, spaceId, reservedDate).isPresent()) {
+                guestId, spaceId, reservedDate).isPresent()) {
             throw new DuplicateException(ReviewErrorCode.REVIEW_ALREADY_EXISTS);
         }
     }
@@ -200,41 +223,58 @@ public class ReviewGuestService {
 
     private Review buildReview(User guest, Reservation reservation, int rating, String content) {
         return Review.builder()
-            .guest(guest)
-            .space(reservation.getSpace())
-            .reservation(reservation)
-            .rating(rating)
-            .content(content)
-            .reservedDate(reservation.getDate())
-            .build();
+                .guest(guest)
+                .space(reservation.getSpace())
+                .reservation(reservation)
+                .rating(rating)
+                .content(content)
+                .reservedDate(reservation.getDate())
+                .build();
     }
 
-    private void saveReviewImages(Review review, List<String> imageUrls) {
-        if (imageUrls != null && !imageUrls.isEmpty()) {
-            List<ReviewImage> images = imageUrls.stream()
-                .map(url -> ReviewImage.builder()
-                    .imageUrl(url)
-                    .build())
-                .toList();
-            for (ReviewImage image : images) {
+    private void saveReviewImages(Review review, List<MultipartFile> images) throws IOException {
+        if (images != null && !images.isEmpty()) {
+            List<ReviewImage> reviewImages = new ArrayList<>();
+
+            for (MultipartFile image : images) {
+                String imageUrl = imageUploader.upload(image);
+                ReviewImage reviewImage = ReviewImage.builder()
+                        .imageUrl(imageUrl)
+                        .build();
+                reviewImages.add(reviewImage);
+            }
+
+            for(ReviewImage image : reviewImages) {
                 review.addImage(image);
             }
             reviewRepository.save(review);
         }
     }
 
-    private void updateReviewImages(Review review, List<String> imageUrls) {
+    private void updateReviewImages(Review review, List<MultipartFile> images) throws IOException {
         // 기존 이미지 삭제
         deleteExistingImages(review);
 
         // 새로운 이미지 저장
-        saveReviewImages(review, imageUrls);
+        saveReviewImages(review, images);
     }
 
     private void deleteExistingImages(Review review) {
         List<ReviewImage> existingImages = review.getImages();
         if (existingImages != null) {
             review.getImages().clear();
+        }
+    }
+
+    private void checkEmptyReservation(Page<Reservation> reservations) {
+        if (reservations.isEmpty()) {
+            throw new ReservationNotFound(ReservationErrorCode.RESERVATION_NOT_FOUND);
+        }
+    }
+
+    private void checkEmptyReviews(Page<Review> reviews) {
+        if (reviews.isEmpty()) {
+            throw new ReviewNotFoundException(ReviewErrorCode.REVIEW_NOT_FOUND);
         }
     }
 }


### PR DESCRIPTION
## ISSUE
[#193] GUEST - 리뷰 리펙토링: 이미지 등록, 페이징, API url 수정, 테스트 코드 수정

## 전달사항
ReviewGuestServiceTest의 "리뷰 작성 - 성공 (이미지 없음)", "리뷰 작성 - 성공 (이미지 포함)" 케이스에서
`assertThat(savedReview.getImages()).isEmpty();`에

`Expecting actual not to be null
java.lang.AssertionError` 에러가 났었습니다..!

GPT: 가장 깔끔한 방법은 Review 엔티티에서 images 필드를 아예 빈 리스트로 초기화 해주는 것입니다.
`@OneToMany(mappedBy = "review", cascade = CascadeType.ALL, orphanRemoval = true)
private List<ReviewImage> images = new ArrayList<>();`

=> 그런데도 해결이 안돼서 
임시대안으로 테스트 코드에 null 체크를 추가했습니다..!
`assertThat(savedReview.getImages() == null || savedReview.getImages().isEmpty()).isTrue();`



