### PR TITLE
[BE] GUEST - 내주변 리펙토링: 페이징, API url 수정

### DIFF
--- a/src/main/java/com/beour/space/domain/repository/SpaceRepository.java
+++ b/src/main/java/com/beour/space/domain/repository/SpaceRepository.java
@@ -28,6 +28,25 @@ public interface SpaceRepository extends JpaRepository<Space, Long> {
         @Param("radius") double radiusInMeters);
 
     @Query(value = """
+        SELECT *
+        FROM space s
+        WHERE s.deleted_at IS NULL
+          AND ST_Distance_Sphere(POINT(s.longitude, s.latitude), POINT(:longitude, :latitude)) <= :radius
+        ORDER BY ST_Distance_Sphere(POINT(s.longitude, s.latitude), POINT(:longitude, :latitude)) ASC
+        """,
+            countQuery = """
+        SELECT COUNT(*)
+        FROM space s
+        WHERE s.deleted_at IS NULL
+          AND ST_Distance_Sphere(POINT(s.longitude, s.latitude), POINT(:longitude, :latitude)) <= :radius
+        """,
+            nativeQuery = true)
+    Page<Space> findAllWithinDistanceWithPaging(@Param("latitude") double latitude,
+                                                @Param("longitude") double longitude,
+                                                @Param("radius") double radiusInMeters,
+                                                Pageable pageable);
+
+    @Query(value = """
         SELECT DISTINCT s.*
         FROM space s
         LEFT JOIN description d ON s.id = d.space_id

--- a/src/main/java/com/beour/space/guest/controller/GuestSpaceController.java
+++ b/src/main/java/com/beour/space/guest/controller/GuestSpaceController.java
@@ -2,7 +2,7 @@ package com.beour.space.guest.controller;
 
 import com.beour.global.response.ApiResponse;
 import com.beour.space.guest.dto.FilteringSearchRequestDto;
-import com.beour.space.guest.dto.NearbySpaceResponse;
+import com.beour.space.guest.dto.NearbySpacePageResponseDto;
 import com.beour.space.guest.dto.RecentCreatedSpcaceListResponseDto;
 import com.beour.space.guest.dto.SearchSpacePageResponseDto;
 import com.beour.space.guest.service.GuestSpaceSearchService;
@@ -31,41 +31,42 @@ public class GuestSpaceController {
     private final GuestSpaceSearchService guestSpaceSearchService;
 
     @GetMapping("/nearby")
-    public ResponseEntity<List<NearbySpaceResponse>> getNearbySpaces(
-        @RequestParam double latitude,
-        @RequestParam double longitude,
-        @RequestParam double radiusKm,
-        @RequestParam long userId
+    public ResponseEntity<NearbySpacePageResponseDto> getNearbySpaces(
+            @RequestParam double latitude,
+            @RequestParam double longitude,
+            @RequestParam double radiusKm,
+            @RequestParam long userId,
+            @PageableDefault(size = 20) Pageable pageable
     ) {
-        List<NearbySpaceResponse> response = guestSpaceService.findNearbySpaces(latitude, longitude,
-            radiusKm, userId);
+        NearbySpacePageResponseDto response = guestSpaceService.findNearbySpaces(
+                latitude, longitude, radiusKm, userId, pageable);
         return ResponseEntity.ok(response);
     }
 
     @GetMapping("/keyword")
     public ApiResponse<SearchSpacePageResponseDto> searchSpaces(
-        @RequestParam(value = "keyword") String request,
-        @PageableDefault(size = 20) Pageable pageable) {
+            @RequestParam(value = "keyword") String request,
+            @PageableDefault(size = 20) Pageable pageable) {
         return ApiResponse.ok(guestSpaceSearchService.search(request, pageable));
     }
 
     @PostMapping("/filter")
     public ApiResponse<SearchSpacePageResponseDto> searchSpacesWithFiltering(
-        @RequestBody FilteringSearchRequestDto requestDto, @PageableDefault(size = 20) Pageable pageable) {
+            @RequestBody FilteringSearchRequestDto requestDto, @PageableDefault(size = 20) Pageable pageable) {
         return ApiResponse.ok(guestSpaceSearchService.searchWithFiltering(requestDto, pageable));
     }
 
     @GetMapping("/spacecategory")
     public ApiResponse<SearchSpacePageResponseDto> searchWithSpaceCategory(
-        @RequestParam(value = "spacecategory") SpaceCategory request,
-        @PageableDefault(size = 20) Pageable pageable) {
+            @RequestParam(value = "spacecategory") SpaceCategory request,
+            @PageableDefault(size = 20) Pageable pageable) {
 
         return ApiResponse.ok(guestSpaceSearchService.searchSpaceWithSpaceCategory(request, pageable));
     }
 
     @GetMapping("/usecategory")
     public ApiResponse<SearchSpacePageResponseDto> searchWithUseCategory(
-        @RequestParam(value = "usecategory") UseCategory request, @PageableDefault(size = 20) Pageable pageable) {
+            @RequestParam(value = "usecategory") UseCategory request, @PageableDefault(size = 20) Pageable pageable) {
 
         return ApiResponse.ok(guestSpaceSearchService.searchSpaceWithUseCategory(request, pageable));
     }

--- a/src/main/java/com/beour/space/guest/dto/NearbySpacePageResponseDto.java
+++ b/src/main/java/com/beour/space/guest/dto/NearbySpacePageResponseDto.java
@@ -1,0 +1,13 @@
+package com.beour.space.guest.dto;
+
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class NearbySpacePageResponseDto {
+    private List<NearbySpaceResponse> spaces;
+    private boolean last;
+    private int totalPage;
+}


### PR DESCRIPTION
## ISSUE
[#194] GUEST - 내주변 리펙토링: 페이징, API url 수정

## 참고: **SpaceRepository 메서드 추가**
- 기존 `findAllWithinDistance()` 메서드는 유지 (하위 호환성)
- 새로운 `findAllWithinDistanceWithPaging()` 메서드 추가
- `countQuery`를 포함한 페이징 쿼리로 구현

