### PR TITLE
fix: api url 중복 수정

### DIFF
--- a/src/main/java/com/beour/global/security/SecurityConfig.java
+++ b/src/main/java/com/beour/global/security/SecurityConfig.java
@@ -61,7 +61,7 @@ public class SecurityConfig {
                         "/api/users/find/login-id", "/api/users/reset/password", "/api/token/reissue",
                         "/api/spaces/keyword", "/api/spaces/filter", "/api/spaces/spacecategory", "/api/spaces/usecategory")
                     .permitAll()
-                    .requestMatchers("/api/spaces/reserve/available-times", "/api/spaces/search/**",
+                    .requestMatchers("/api/spaces/reserve/available-times/date", "/api/spaces/search/**",
                         "/api/spaces/new", "/api/reviews/new", "/api/banners", "/api/spaces/*/available-times").permitAll()
                     .requestMatchers("/api/spaces/*/reservations", "/api/reservations/current/*", "/api/reservations/past/*","/api/spaces/reserve", "/api/reservation/**", "/api/guest/**",
                         "/api/spaces/*/likes", "/api/likes")

--- a/src/main/java/com/beour/reservation/guest/controller/ReservationGuestController.java
+++ b/src/main/java/com/beour/reservation/guest/controller/ReservationGuestController.java
@@ -34,7 +34,7 @@ public class ReservationGuestController {
         return ApiResponse.ok(reservationGuestService.createReservation(spaceId, requestDto));
     }
 
-    @GetMapping("/api/spaces/{spaceId}/available-times")
+    @GetMapping("/api/spaces/{spaceId}/available-times/date")
     public ApiResponse<SpaceAvailableTimeResponseDto> checkAvailableTimes(
         @PathVariable(value = "spaceId") Long spaceId, @RequestParam(value = "date")
     LocalDate date) {

--- a/src/test/java/com/beour/reservation/guest/controller/ReservationGuestControllerTest.java
+++ b/src/test/java/com/beour/reservation/guest/controller/ReservationGuestControllerTest.java
@@ -354,7 +354,7 @@ class ReservationGuestControllerTest {
     @DisplayName("이용 가능한 시간 조회 - 과거 날짜로 조회")
     void check_available_time_with_past_date() throws Exception {
         //when  then
-        mockMvc.perform(get("/api/spaces/"+ space.getId() +"/available-times?date=" + LocalDate.now().minusDays(1))
+        mockMvc.perform(get("/api/spaces/"+ space.getId() +"/available-times/date?date=" + LocalDate.now().minusDays(1))
                 .header("Authorization", "Bearer " + accessToken)
                 .contentType(MediaType.APPLICATION_JSON)
             )
@@ -372,7 +372,7 @@ class ReservationGuestControllerTest {
         }
 
         //when  then
-        mockMvc.perform(get("/api/spaces/"+ space.getId() +"/available-times?date=" + LocalDate.now())
+        mockMvc.perform(get("/api/spaces/"+ space.getId() +"/available-times/date?date=" + LocalDate.now())
                 .header("Authorization", "Bearer " + accessToken)
                 .contentType(MediaType.APPLICATION_JSON)
             )
@@ -385,7 +385,7 @@ class ReservationGuestControllerTest {
     @DisplayName("이용 가능한 시간 조회 - 가능한 시간 없을 경우")
     void check_available_time_not_found() throws Exception {
         //when  then
-        mockMvc.perform(get("/api/spaces/"+ space.getId() +"/available-times?date=" + LocalDate.now().plusDays(3))
+        mockMvc.perform(get("/api/spaces/"+ space.getId() +"/available-times/date?date=" + LocalDate.now().plusDays(3))
                 .header("Authorization", "Bearer " + accessToken)
                 .contentType(MediaType.APPLICATION_JSON)
             )
@@ -418,7 +418,7 @@ class ReservationGuestControllerTest {
         }
 
         //when  then
-        mockMvc.perform(get("/api/spaces/"+ space.getId() +"/available-times?date=" + LocalDate.now().plusDays(1))
+        mockMvc.perform(get("/api/spaces/"+ space.getId() +"/available-times/date?date=" + LocalDate.now().plusDays(1))
                 .header("Authorization", "Bearer " + accessToken)
                 .contentType(MediaType.APPLICATION_JSON)
             )
@@ -454,7 +454,7 @@ class ReservationGuestControllerTest {
         }
 
         //when  then
-        mockMvc.perform(get("/api/spaces/"+ space.getId() +"/available-times?date=" + LocalDate.now().plusDays(1))
+        mockMvc.perform(get("/api/spaces/"+ space.getId() +"/available-times/date?date=" + LocalDate.now().plusDays(1))
                 .header("Authorization", "Bearer " + accessToken)
                 .contentType(MediaType.APPLICATION_JSON)
             )


### PR DESCRIPTION
- 중복된 api url을 수정한다.

- 게스트의 예약가능 시간 조회 api url를 아래와 같이 수정한다.
   /api/spaces/{spaceId}/available-times?date={date}   ->   /api/spaces/{spaceId}/available-times/date?date={date}