### PR TITLE
[#215] refactor: SecurityConfig url 접근 권한 매핑 수정

### DIFF
--- a/src/main/java/com/beour/global/config/CorsConfig.java
+++ b/src/main/java/com/beour/global/config/CorsConfig.java
@@ -23,7 +23,7 @@ public class CorsConfig {
             "https://localhost:3000",
             "https://beour.store",
             "https://www.beour.store",
-            "http://beour-bucket.s3-website.ap-northeast-2.amazonaws.com"
+            "https://frontend.beour.store"
         ));
 
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));

--- a/src/main/java/com/beour/global/jwt/LoginFilter.java
+++ b/src/main/java/com/beour/global/jwt/LoginFilter.java
@@ -39,6 +39,9 @@ public class LoginFilter extends UsernamePasswordAuthenticationFilter {
     @Override
     public Authentication attemptAuthentication(HttpServletRequest request,
         HttpServletResponse response) {
+        if ("OPTIONS".equalsIgnoreCase(request.getMethod())) {
+            return null; // 또는 그냥 return
+        }
 
         try {
             LoginDto loginDto = new ObjectMapper().readValue(request.getInputStream(),

--- a/src/main/java/com/beour/global/security/SecurityConfig.java
+++ b/src/main/java/com/beour/global/security/SecurityConfig.java
@@ -55,26 +55,61 @@ public class SecurityConfig {
 
         http
             .authorizeHttpRequests((auth) -> auth
-                    .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
-                    .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
-                    .requestMatchers("/api/signup/**", "/api/login",
-                        "/api/users/find/login-id", "/api/users/reset/password", "/api/token/reissue",
-                        "/api/spaces/keyword", "/api/spaces/filter", "/api/spaces/spacecategory", "/api/spaces/usecategory")
-                    .permitAll()
-                    .requestMatchers("/api/spaces/reserve/available-times/date", "/api/spaces/search/**",
-                        "/api/spaces/new", "/api/reviews/new", "/api/banners", "/api/spaces/*/available-times").permitAll()
-                    .requestMatchers("/api/spaces/*/reservations", "/api/reservations/current/*", "/api/reservations/past/*","/api/spaces/reserve", "/api/reservation/**", "/api/guest/**",
-                        "/api/spaces/*/likes", "/api/likes")
-                    .hasRole("GUEST")
-                    .requestMatchers("/api/spaces", "/api/spaces/my-spaces", "/api/spaces/*",
-                        "/api/spaces/*/*", "/api/reservations/condition",
-                        "/api/host/available-times/spaces", "/api/host/available-times/space/*")
-                    .hasRole("HOST")
-                    .requestMatchers("/api/mypage/**").hasAnyRole("HOST", "GUEST")
-                    .requestMatchers("/api/logout", "/api/users", "/api/users/me/**")
-                    .hasAnyRole("HOST", "GUEST", "ADMIN")
-                    .anyRequest().authenticated()
-//                    .anyRequest().permitAll()
+                .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+                .requestMatchers("/swagger-ui/**", "/v3/api-docs/**").permitAll()
+
+                // all - 로그인, 회원가입 등
+                .requestMatchers("/api/signup", "/api/signup/check-duplicate/login-id",
+                    "/api/signup/check-duplicate/nickname", "/api/login",
+                    "/api/users/find/login-id", "/api/users/reset/password")
+                .permitAll()
+
+                // all - 공간 검색 및 이용가능 시간
+                .requestMatchers("/api/spaces/*/available-times/date", "/api/reviews/new",
+                    "/api/spaces/nearby", "/api/spaces/keyword", "/api/spaces/filter",
+                    "/api/spaces/spacecategory", "/api/spaces/usecategory", "/api/spaces/new")
+                .permitAll()
+
+                //host - 공간 예약
+                .requestMatchers("/api/reservations/condition", "/api/reservations/*/accept",
+                    "/api/reservations/*/reject", "/api/users/me/spaces-name", "/api/reservations",
+                    "/api/spaces/reservations").hasRole("HOST")
+
+                //host - 공간 예약
+                .requestMatchers("/api/reservations/condition", "/api/reservations/*/accept",
+                    "/api/reservations/*/reject", "/api/users/me/spaces-name", "/api/reservations",
+                    "/api/spaces/reservations").hasRole("HOST")
+
+                //host - 공간
+                .requestMatchers("/api/spaces", "/api/spaces/*/simple", "/api/spaces/*",
+                    "/api/spaces/*/basic", "/api/spaces/*/description", "/api/spaces/*/tags",
+                    "/api/spaces/*/images", "/api/spaces/*/available-times").hasRole("HOST")
+
+                // host - 댓글
+                .requestMatchers("/api/users/me/commentable-reviews",
+                    "/api/users/me/review-comments", "/api/users/me/review-comments/*")
+                .hasRole("HOST")
+
+                // guest - 예약
+                .requestMatchers("/api/spaces/*/reservations", "/api/reservations/current",
+                    "/api/reservations/past", "/api/reservations/*").hasRole("GUEST")
+
+                // guest - 리뷰
+                .requestMatchers("/api/users/me/reviewable-reservations", "/api/users/me/reviews",
+                    "/api/reviews/reservations/*", "/api/users/me/reviews/*").hasRole("GUEST")
+
+                // guest - 찜
+                .requestMatchers("/api/likes","/api/spaces/*/likes").hasRole("GUEST")
+
+                //admin
+                .requestMatchers("/api/banners", "/admin/banner/list").hasRole("ADMIN")
+
+                //guest, host, admin
+                .requestMatchers("/api/token/reissue", "api/users", "api/users/me",
+                    "api/users/me/detail", "api/users/me/password", "/api/logout")
+                .hasAnyRole("HOST", "GUEST", "ADMIN")
+
+                .anyRequest().authenticated()
             );
 
         http

--- a/src/test/java/com/beour/reservation/host/controller/ReservationHostControllerTest.java
+++ b/src/test/java/com/beour/reservation/host/controller/ReservationHostControllerTest.java
@@ -176,8 +176,7 @@ class ReservationHostControllerTest {
         mockMvc.perform(get("/api/users/me/spaces-name")
                         .header("Authorization", "Bearer " + guestAccessToken)
                 )
-                .andExpect(status().isNotFound())
-                .andExpect(jsonPath("$.message").value(SpaceErrorCode.NO_HOST_SPACE.getMessage()));
+                .andExpect(status().isForbidden());
     }
 
     @Test

--- a/src/test/java/com/beour/user/controller/LoginControllerTest.java
+++ b/src/test/java/com/beour/user/controller/LoginControllerTest.java
@@ -44,6 +44,7 @@ class LoginControllerTest {
     private BCryptPasswordEncoder passwordEncoder;
     @Autowired
     private JWTUtil jwtUtil;
+    private String accessToken;
 
     @BeforeEach
     void setUp() {
@@ -58,6 +59,13 @@ class LoginControllerTest {
             .role("GUEST")
             .build();
         userRepository.save(user);
+
+        accessToken = jwtUtil.createJwt(
+            "access",
+            user.getLoginId(),
+            "ROLE_" + user.getRole(),
+            1000L * 60 * 30 // 30분
+        );
 
         User deleteUser = User.builder()
             .name("탈퇴유저")
@@ -315,7 +323,8 @@ class LoginControllerTest {
         Cookie cookie = new Cookie("refresh", refreshToken);
 
         //when  then
-        mockMvc.perform(post("/api/token/reissue").cookie(cookie))
+        mockMvc.perform(post("/api/token/reissue").cookie(cookie)
+                .header("Authorization", "Bearer " + accessToken))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.data.accessToken").exists())
             .andExpect(cookie().exists("refresh"))
@@ -326,7 +335,7 @@ class LoginControllerTest {
     @DisplayName("토큰 재발급 - refresh 토큰 없음")
     void reissue_refresh_token_not_found() throws Exception {
         //when  then
-        mockMvc.perform(post("/api/token/reissue"))
+        mockMvc.perform(post("/api/token/reissue").header("Authorization", "Bearer " + accessToken))
             .andExpect(status().isNotFound())
             .andExpect(
                 jsonPath("$.message").value(UserErrorCode.REFRESH_TOKEN_NOT_FOUND.getMessage()));
@@ -350,7 +359,8 @@ class LoginControllerTest {
         Cookie cookie = new Cookie("refresh", refreshToken);
 
         //when  then
-        mockMvc.perform(post("/api/token/reissue").cookie(cookie))
+        mockMvc.perform(post("/api/token/reissue").cookie(cookie)
+                .header("Authorization", "Bearer " + accessToken))
             .andExpect(status().isNotFound())
             .andExpect(
                 jsonPath("$.message").value(UserErrorCode.REFRESH_TOKEN_NOT_FOUND.getMessage()));
@@ -375,7 +385,8 @@ class LoginControllerTest {
         Cookie cookie = new Cookie("refresh", refreshToken);
 
         //when  then
-        mockMvc.perform(post("/api/token/reissue").cookie(cookie))
+        mockMvc.perform(post("/api/token/reissue").cookie(cookie)
+                .header("Authorization", "Bearer " + accessToken))
             .andExpect(status().isUnauthorized())
             .andExpect(
                 jsonPath("$.message").value(UserErrorCode.REFRESH_TOKEN_EXPIRED.getMessage()));


### PR DESCRIPTION
## ISSUE
[#215] Spring Security URL 접근 권한 매핑 정리 및 수정한다.

## 변경사항
- SecurityConfig 리팩토링
   - GUEST, HOST, ADMIN 권한 별로 요청 경로 정리
   - 중복된 경로 제거 및 정렬
- 테스트 코드 개선
  - /api/token/reissue에 권한 설정하며 LoginControllerTest에  accesstoken 추가   
  - ReservationHostControllerTest 응답코드 수정