### PR TITLE
[BE] fix: Reservation관련 Test코드 DateTimeException

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+env:
+  TZ: Asia/Seoul
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/src/test/java/com/beour/reservation/commons/repository/ReservationRepositoryTest.java
+++ b/src/test/java/com/beour/reservation/commons/repository/ReservationRepositoryTest.java
@@ -232,8 +232,8 @@ class ReservationRepositoryTest {
             .usagePurpose(UsagePurpose.BARISTA_TRAINING)
             .requestMessage("테슽뚜")
             .date(LocalDate.now())
-            .startTime(LocalTime.of(currentTime - 1, 0, 0))
-            .endTime(LocalTime.of(currentTime + 1, 0, 0))
+            .startTime(LocalTime.of((currentTime - 1 + 24) % 24, 0, 0))
+            .endTime(LocalTime.of((currentTime + 1) % 24, 0, 0))
             .price(30000)
             .guestCount(2)
             .build();
@@ -247,8 +247,8 @@ class ReservationRepositoryTest {
             .usagePurpose(UsagePurpose.BARISTA_TRAINING)
             .requestMessage("테슽뚜")
             .date(LocalDate.now())
-            .startTime(LocalTime.of(currentTime + 1, 0, 0))
-            .endTime(LocalTime.of(currentTime + 2, 0, 0))
+            .startTime(LocalTime.of((currentTime + 1) % 24, 0, 0))
+            .endTime(LocalTime.of((currentTime + 2) % 24, 0, 0))
             .price(15000)
             .guestCount(2)
             .build();
@@ -282,8 +282,8 @@ class ReservationRepositoryTest {
             .usagePurpose(UsagePurpose.BARISTA_TRAINING)
             .requestMessage("테슽뚜")
             .date(LocalDate.now())
-            .startTime(LocalTime.of(currentTime - 3, 0, 0))
-            .endTime(LocalTime.of(currentTime - 1, 0, 0))
+            .startTime(LocalTime.of((currentTime - 3 + 24) % 24, 0, 0))
+            .endTime(LocalTime.of((currentTime - 1 + 24) % 24, 0, 0))
             .price(30000)
             .guestCount(2)
             .build();
@@ -297,8 +297,8 @@ class ReservationRepositoryTest {
             .usagePurpose(UsagePurpose.BARISTA_TRAINING)
             .requestMessage("테슽뚜")
             .date(LocalDate.now())
-            .startTime(LocalTime.of(currentTime + 1, 0, 0))
-            .endTime(LocalTime.of(currentTime + 2, 0, 0))
+            .startTime(LocalTime.of((currentTime + 1) % 24, 0, 0))
+            .endTime(LocalTime.of((currentTime + 2) % 24, 0, 0))
             .price(15000)
             .guestCount(2)
             .build();

--- a/src/test/java/com/beour/reservation/guest/service/ReservationGuestServiceTest.java
+++ b/src/test/java/com/beour/reservation/guest/service/ReservationGuestServiceTest.java
@@ -175,7 +175,7 @@ class ReservationGuestServiceTest {
         //given
         int currentHour = LocalTime.now().getHour();
         ReservationCreateRequest request = new ReservationCreateRequest(LocalDate.now(), LocalTime.of(currentHour - 1, 0, 0),
-            LocalTime.of(currentHour + 1, 0, 0), 30000, 2,
+            LocalTime.of((currentHour + 1) % 24, 0, 0), 30000, 2,
             UsagePurpose.BARISTA_TRAINING, "테슽뚜");
 
         //when  then
@@ -317,8 +317,8 @@ class ReservationGuestServiceTest {
             .usagePurpose(UsagePurpose.BARISTA_TRAINING)
             .requestMessage("테슽뚜")
             .date(LocalDate.now())
-            .startTime(LocalTime.of(currentTime - 3, 0, 0))
-            .endTime(LocalTime.of(currentTime - 1, 0, 0))
+            .startTime(LocalTime.of((currentTime - 3 + 24) % 24, 0, 0))
+            .endTime(LocalTime.of((currentTime - 1 + 24) % 24, 0, 0))
             .price(30000)
             .guestCount(2)
             .build();
@@ -331,8 +331,8 @@ class ReservationGuestServiceTest {
             .usagePurpose(UsagePurpose.BARISTA_TRAINING)
             .requestMessage("테슽뚜")
             .date(LocalDate.now())
-            .startTime(LocalTime.of(currentTime + 1, 0, 0))
-            .endTime(LocalTime.of(currentTime + 2, 0, 0))
+            .startTime(LocalTime.of((currentTime + 1) % 24, 0, 0))
+            .endTime(LocalTime.of((currentTime + 2) % 24, 0, 0))
             .price(15000)
             .guestCount(2)
             .build();

--- a/src/test/java/com/beour/reservation/host/service/ReservationHostServiceTest.java
+++ b/src/test/java/com/beour/reservation/host/service/ReservationHostServiceTest.java
@@ -575,8 +575,8 @@ class ReservationHostServiceTest {
                     .usagePurpose(UsagePurpose.BARISTA_TRAINING)
                     .requestMessage("예약 " + (i + 1))
                     .date(targetDate)
-                    .startTime(LocalTime.of(10 + i, 0, 0))
-                    .endTime(LocalTime.of(12 + i, 0, 0))
+                    .startTime(LocalTime.of((10 + i) % 24, 0, 0))
+                    .endTime(LocalTime.of((12 + i) % 24, 0, 0))
                     .price(30000)
                     .guestCount(2)
                     .build();
@@ -610,8 +610,8 @@ class ReservationHostServiceTest {
                     .usagePurpose(UsagePurpose.BARISTA_TRAINING)
                     .requestMessage("예약 " + (i + 1))
                     .date(targetDate)
-                    .startTime(LocalTime.of(10 + i, 0, 0))
-                    .endTime(LocalTime.of(12 + i, 0, 0))
+                    .startTime(LocalTime.of((10 + i) % 24, 0, 0))
+                    .endTime(LocalTime.of((12 + i) % 24, 0, 0))
                     .price(30000)
                     .guestCount(2)
                     .build();


### PR DESCRIPTION
## ISSUE
[#258] LocalTime.of(...)에 음수가 들어가는 버그
```java
LocalTime.of(currentTime - 3, 0, 0)
```

에서 시(hour)가 **0 미만** 또는 **23 초과*로 `java.time.DateTimeException` 발생

---

## 수정 사항
1. **시간 생성 로직 보정**
```java
int currentTime = LocalTime.now().getHour();
int pastHour = (currentTime - 3 + 24) % 24; // 음수 방지
int futureHour = (currentTime + 1) % 24;
```

2. **UTC → KST 고정**
   테스트 실행 시 `TZ=Asia/Seoul` 환경변수를 GitHub Actions에서 설정
=> `LocalTime.now()`가 로컬과 동일한 한국 시간으로 동작함.
```yaml
env:
  TZ: Asia/Seoul
```

