### PR TITLE
[BE] fix: 이미 작성된 리뷰를 필터링 해주는 로직추가

### DIFF
--- a/src/main/java/com/beour/reservation/commons/repository/ReservationRepository.java
+++ b/src/main/java/com/beour/reservation/commons/repository/ReservationRepository.java
@@ -46,8 +46,12 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
     WHERE r.guest.id = :guestId 
     AND r.status = 'COMPLETED'
     AND r.deletedAt IS NULL
+    AND NOT EXISTS (
+        SELECT rev FROM Review rev
+        WHERE rev.reservation = r
+    )
     """)
-    Page<Reservation> findCompletedReservationsByGuestId(@Param("guestId") Long guestId, Pageable pageable);
+    Page<Reservation> findReviewableReservationsByGuestId(@Param("guestId") Long guestId, Pageable pageable);
 
     @Query("SELECT r FROM Reservation r JOIN FETCH r.space WHERE r.guest.id = :guestId AND r.status = 'COMPLETED' AND r.deletedAt IS NULL")
     List<Reservation> findCompletedReservationsWithSpaceByGuestId(@Param("guestId") Long guestId);

--- a/src/main/java/com/beour/review/guest/service/ReviewGuestService.java
+++ b/src/main/java/com/beour/review/guest/service/ReviewGuestService.java
@@ -55,8 +55,9 @@ public class ReviewGuestService {
     public ReviewableReservationPageResponseDto getReviewableReservations(Pageable pageable) {
         User guest = findUserFromToken();
 
+        // 완료된 예약 + 이미 해당 예약에 리뷰가 작성되어 있는 지 확인
         Page<Reservation> completedReservations = reservationRepository
-                .findCompletedReservationsByGuestId(guest.getId(), pageable);
+                .findReviewableReservationsByGuestId(guest.getId(), pageable);
 
         checkEmptyReservation(completedReservations);
 

--- a/src/main/java/com/beour/review/guest/service/ReviewGuestService.java
+++ b/src/main/java/com/beour/review/guest/service/ReviewGuestService.java
@@ -59,8 +59,6 @@ public class ReviewGuestService {
         Page<Reservation> completedReservations = reservationRepository
                 .findReviewableReservationsByGuestId(guest.getId(), pageable);
 
-        checkEmptyReservation(completedReservations);
-
         List<ReviewableReservationResponseDto> reservations = completedReservations.getContent().stream()
                 .map(ReviewableReservationResponseDto::of)
                 .toList();
@@ -262,12 +260,6 @@ public class ReviewGuestService {
         List<ReviewImage> existingImages = review.getImages();
         if (existingImages != null) {
             review.getImages().clear();
-        }
-    }
-
-    private void checkEmptyReservation(Page<Reservation> reservations) {
-        if (reservations.isEmpty()) {
-            throw new ReservationNotFound(ReservationErrorCode.RESERVATION_NOT_FOUND);
         }
     }
 

--- a/src/main/java/com/beour/review/host/service/ReviewCommentHostService.java
+++ b/src/main/java/com/beour/review/host/service/ReviewCommentHostService.java
@@ -45,10 +45,6 @@ public class ReviewCommentHostService {
 
         Page<Review> commentableReviewsPage = reviewRepository.findCommentableReviewsByHostId(host.getId(), pageable);
 
-        if (commentableReviewsPage.isEmpty()) {
-            throw new IllegalStateException("답글을 작성할 수 있는 리뷰가 없습니다.");
-        }
-
         List<ReviewCommentableResponseDto> reviews = commentableReviewsPage.getContent()
                 .stream()
                 .map(ReviewCommentableResponseDto::of)

--- a/src/test/java/com/beour/review/guest/controller/ReviewGuestControllerTest.java
+++ b/src/test/java/com/beour/review/guest/controller/ReviewGuestControllerTest.java
@@ -170,8 +170,11 @@ class ReviewGuestControllerTest {
     }
 
     @Test
-    @DisplayName("리뷰 가능한 예약 조회 - 성공 (페이징)")
-    void getReviewableReservations_success() throws Exception {
+    @DisplayName("리뷰 가능한 예약 조회 - 성공 (리뷰 없는 예약 반환)")
+    void getReviewableReservations_success_withoutReview() throws Exception {
+        // given: 리뷰 없는 예약만 세팅 (review 저장 X)
+        reviewRepository.deleteAll(); // setUp에서 저장한 리뷰 제거
+
         mockMvc.perform(get("/api/users/me/reviewable-reservations")
                         .param("page", "0")
                         .param("size", "10")
@@ -182,6 +185,19 @@ class ReviewGuestControllerTest {
                 .andExpect(jsonPath("$.data.reservations[0].date").value(completedReservation.getDate().toString()))
                 .andExpect(jsonPath("$.data.reservations[0].guestCount").value(2))
                 .andExpect(jsonPath("$.data.reservations[0].usagePurpose").value(UsagePurpose.BARISTA_TRAINING.getText()))
+                .andExpect(jsonPath("$.data.last").exists())
+                .andExpect(jsonPath("$.data.totalPage").exists());
+    }
+
+    @Test
+    @DisplayName("리뷰 가능한 예약 조회 - 성공 (리뷰가 있으면 제외)")
+    void getReviewableReservations_success_withReviewExcluded() throws Exception {
+        mockMvc.perform(get("/api/users/me/reviewable-reservations")
+                        .param("page", "0")
+                        .param("size", "10")
+                        .header("Authorization", "Bearer " + accessToken))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.reservations").isEmpty())
                 .andExpect(jsonPath("$.data.last").exists())
                 .andExpect(jsonPath("$.data.totalPage").exists());
     }

--- a/src/test/java/com/beour/review/guest/service/ReviewGuestServiceTest.java
+++ b/src/test/java/com/beour/review/guest/service/ReviewGuestServiceTest.java
@@ -209,9 +209,14 @@ class ReviewGuestServiceTest {
         // 완료된 예약 삭제
         reservationRepository.delete(completedReservation);
 
-        //when then
-        assertThrows(ReservationNotFound.class,
-                () -> reviewGuestService.getReviewableReservations(pageable));
+        // when
+        ReviewableReservationPageResponseDto result = reviewGuestService.getReviewableReservations(pageable);
+
+        // then
+        assertNotNull(result);
+        assertTrue(result.getReservations().isEmpty(), "리뷰 가능한 예약이 없으면 빈 리스트를 반환");
+        assertEquals(0, result.getTotalPage());
+        assertTrue(result.isLast());
     }
 
     @Test

--- a/src/test/java/com/beour/review/host/service/ReviewCommentHostServiceTest.java
+++ b/src/test/java/com/beour/review/host/service/ReviewCommentHostServiceTest.java
@@ -245,9 +245,15 @@ class ReviewCommentHostServiceTest {
 
         Pageable pageable = PageRequest.of(0, 10);
 
-        // when & then
-        assertThrows(IllegalStateException.class,
-                () -> reviewCommentHostService.getCommentableReviews(pageable));
+        // when
+        ReviewCommentablePageResponseDto result = reviewCommentHostService.getCommentableReviews(pageable);
+
+        // then
+        assertNotNull(result);
+        assertTrue(result.getReviews().isEmpty(), "대댓글 가능한 리뷰가 없으면 빈 리스트를 반환");
+        // 페이징 정보도 확인 가능
+        assertEquals(0, result.getTotalPage());
+        assertTrue(result.isLast());
     }
 
     @Test


### PR DESCRIPTION
## ISSUE
#261 

## [버그 원인 및 해결]
1. 리뷰 작성 가능한 목록 GET API에서 findCompletedReservationsByGuestId() 로직(공간 이용 완료만 체크)만 있고, 이미 작성된 리뷰를 필터링 해주는 로직이 빠져있음.

추가로 '호스트 - 리뷰 대댓글' 로직에는 이미 작성된 대댓글을 필터링 해주는 기능이 이미 들어있음. 수정할 필요없음

2. (추가) 원래는 리뷰/대댓글 작성이 불가능할 경우에 대해 예외처리(404)해뒀는데 -> 빈 배열을 응답해주도록 수정함.